### PR TITLE
Add rules and guidelines pages

### DIFF
--- a/data/games/climax.xml
+++ b/data/games/climax.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<game>
+  <name>F-Zero Climax</name>
+  <rules_template>rules/climax.html</rules_template>
+</game>

--- a/data/games/gpl.xml
+++ b/data/games/gpl.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<game>
+  <name>F-Zero: GP Legend</name>
+  <rules_template>rules/gpl.html</rules_template>
+</game>

--- a/data/games/gx.xml
+++ b/data/games/gx.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<game>
+  <name>F-Zero GX</name>
+  <rules_template>rules/gx.html</rules_template>
+</game>

--- a/data/games/mv.xml
+++ b/data/games/mv.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<game>
+  <name>F-Zero: Maximum Velocity</name>
+  <rules_template>rules/mv.html</rules_template>
+</game>

--- a/data/games/snes.xml
+++ b/data/games/snes.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<game>
+  <name>F-Zero</name>
+  <rules_template>rules/snes.html</rules_template>
+</game>

--- a/data/games/x.xml
+++ b/data/games/x.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<game>
+  <name>F-Zero X</name>
+  <rules_template>rules/x.html</rules_template>
+</game>

--- a/data/ladders/ladder1.xml
+++ b/data/ladders/ladder1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
 	<ladder_name>SNES</ladder_name>
-	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/viewtopic.php?t=841"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;All European PAL times are converted to NTSC using the formula NTSC = (PAL / 4) * 3 and the converse PAL = (NTSC * 4) / 3&lt;/li&gt;&lt;/ul&gt;</description>
+	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=snes" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;All European PAL times are converted to NTSC using the formula NTSC = (PAL / 4) * 3 and the converse PAL = (NTSC * 4) / 3&lt;/li&gt;&lt;/ul&gt;</description>
 	<hasspeed>No</hasspeed>
 	<haslap>Yes</haslap>
 	<hassettings>No</hassettings>
@@ -12,7 +12,7 @@
 	<pal_denominator>3</pal_denominator>
 	<numtracks>15</numtracks>
 	<cups>
-	<cup cupid="1">   
+	<cup cupid="1">
 	<cupname>Knight Cup</cupname>
 	<courses>
 	<course courseid="1">
@@ -32,7 +32,7 @@
 	</course>
 	</courses>
 	</cup>
-	<cup cupid="2">   
+	<cup cupid="2">
 	<cupname>Queen Cup</cupname>
 	<courses>
 	<course courseid="1">
@@ -52,7 +52,7 @@
 	</course>
 	</courses>
 	</cup>
-	<cup cupid="3">   
+	<cup cupid="3">
 	<cupname>King Cup</cupname>
 	<courses>
 	<course courseid="1">

--- a/data/ladders/ladder11.xml
+++ b/data/ladders/ladder11.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
  <ladder_name>GX Story Mode - Max Speed</ladder_name>
- <description>&lt;ul&gt;&lt;li&gt;Submit your Story Mode times on this ladder, you can compete on any difficulty setting.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;Always save proof - save a ghost and replay of your best times.&lt;/li&gt;&lt;li&gt;Don't cheat - snaking and spaceflying ARE NOT allowed in this ladder.&lt;/li&gt;&lt;li&gt;All times in this ladder must be set while at 100% Max Speed settings&lt;/li&gt;&lt;li&gt;This Ladder does not count towards your championship ladder rank&lt;/li&gt;&lt;/ul&gt;</description>
+ <description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=gx" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;Always save proof - save a ghost and replay of your best times.&lt;/li&gt;&lt;li&gt;Don't cheat - snaking and spaceflying ARE NOT allowed in this ladder.&lt;/li&gt;&lt;li&gt;All times in this ladder must be set while at 100% Max Speed settings&lt;/li&gt;&lt;li&gt;This Ladder does not count towards your championship ladder rank&lt;/li&gt;&lt;/ul&gt;</description>
  <hasspeed>No</hasspeed>
  <haslap>No</haslap>
  <hassettings>No</hassettings>
@@ -9,7 +9,7 @@
 <graphics_available>Yes</graphics_available>
   <palpossible>No</palpossible>
  <cups>
-  <cup cupid="1">   
+  <cup cupid="1">
    <cupname>Normal</cupname>
    <courses>
  <course courseid="1">
@@ -41,7 +41,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="2">   
+  <cup cupid="2">
    <cupname>Hard</cupname>
    <courses>
  <course courseid="1">
@@ -73,7 +73,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="3">   
+  <cup cupid="3">
    <cupname>Very Hard</cupname>
    <courses>
  <course courseid="1">

--- a/data/ladders/ladder12.xml
+++ b/data/ladders/ladder12.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
  <ladder_name>GX Story Mode - Snaking</ladder_name>
- <description>&lt;ul&gt;&lt;li&gt;Submit your Story Mode times on this ladder, you can compete on any difficulty setting.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;Always save proof - save a ghost and replay of your best times.&lt;/li&gt;&lt;li&gt;Don't cheat - but snaking IS allowed in this ladder.&lt;/li&gt;&lt;li&gt;All times in this ladder must be set while at 0% settings&lt;/li&gt;&lt;li&gt;This Ladder does not count towards your championship ladder rank&lt;/li&gt;&lt;/ul&gt;</description>
+ <description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=gx" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;Always save proof - save a ghost and replay of your best times.&lt;/li&gt;&lt;li&gt;Don't cheat - but snaking IS allowed in this ladder.&lt;/li&gt;&lt;li&gt;All times in this ladder must be set while at 0% settings&lt;/li&gt;&lt;li&gt;This Ladder does not count towards your championship ladder rank&lt;/li&gt;&lt;/ul&gt;</description>
  <hasspeed>No</hasspeed>
  <haslap>No</haslap>
  <hassettings>No</hassettings>
@@ -9,7 +9,7 @@
 <graphics_available>Yes</graphics_available>
   <palpossible>No</palpossible>
  <cups>
-  <cup cupid="1">   
+  <cup cupid="1">
    <cupname>Normal</cupname>
    <courses>
  <course courseid="1">
@@ -41,7 +41,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="2">   
+  <cup cupid="2">
    <cupname>Hard</cupname>
    <courses>
  <course courseid="1">
@@ -73,7 +73,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="3">   
+  <cup cupid="3">
    <cupname>Very Hard</cupname>
    <courses>
  <course courseid="1">

--- a/data/ladders/ladder13.xml
+++ b/data/ladders/ladder13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
  <ladder_name>GP Legend Zero Test</ladder_name>
- <description>&lt;ul&gt;&lt;li&gt;Submit your GP Legend Zero Test times on this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;The same general GP Legend &lt;a href="/viewtopic.php?t=13683"&gt;rules&lt;/a&gt; apply to this ladder&lt;/li&gt;&lt;li&gt;This Ladder does not count towards your championship ladder rank&lt;/li&gt;&lt;/ul&gt;</description>
+ <description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=gpl" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;This Ladder does not count towards your championship ladder rank&lt;/li&gt;&lt;/ul&gt;</description>
  <hasspeed>No</hasspeed>
  <haslap>No</haslap>
  <hassettings>No</hassettings>
@@ -9,7 +9,7 @@
 <graphics_available>Yes</graphics_available>
   <palpossible>No</palpossible>
  <cups>
-  <cup cupid="1">   
+  <cup cupid="1">
    <cupname>Class C</cupname>
    <courses>
  <course courseid="1">
@@ -50,7 +50,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="2">   
+  <cup cupid="2">
    <cupname>Class B</cupname>
    <courses>
  <course courseid="1">
@@ -91,7 +91,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="3">   
+  <cup cupid="3">
    <cupname>Class A</cupname>
    <courses>
  <course courseid="1">
@@ -132,7 +132,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="4">   
+  <cup cupid="4">
       <cupname>Class S</cupname>
    <courses>
  <course courseid="1">
@@ -175,39 +175,39 @@
   </cup>
  </cups>
  <ships>
-  <ship>Dragon Bird</ship> 
-  <ship>Blue Falcon</ship> 
-  <ship>Golden Fox</ship> 
-  <ship>Wild Goose</ship> 
-  <ship>Fire Stingray</ship> 
-  <ship>White Cat</ship> 
-  <ship>Astro Robin</ship> 
-  <ship>Death Anchor</ship> 
-  <ship>Panzer Emerald</ship> 
-  <ship>Red Gazelle</ship> 
-  <ship>Iron Tiger</ship> 
-  <ship>Deep Claw</ship> 
-  <ship>Crazy Bear</ship> 
-  <ship>Big Fang</ship> 
-  <ship>Mad Wolf</ship> 
-  <ship>Wonder Wasp</ship> 
-  <ship>Wild Boar</ship> 
-  <ship>Super Piranha</ship> 
-  <ship>Mighty Hurricane</ship> 
-  <ship>Space Angler</ship> 
-  <ship>Mighty Typhoon</ship> 
-  <ship>Green Panther</ship> 
-  <ship>Blood Hawk</ship> 
-  <ship>Black Bull</ship> 
-  <ship>Great Star</ship> 
-  <ship>Twin Noritta</ship> 
-  <ship>Queen Meteor</ship> 
-  <ship>Little Wyvern</ship> 
-  <ship>King Meteor</ship> 
-  <ship>Hyper Speeder</ship> 
-  <ship>Night Thunder</ship> 
-  <ship>Sonic Phantom</ship> 
-  <ship>Elegance Liberty</ship> 
-  <ship>Moon Shadow</ship> 
+  <ship>Dragon Bird</ship>
+  <ship>Blue Falcon</ship>
+  <ship>Golden Fox</ship>
+  <ship>Wild Goose</ship>
+  <ship>Fire Stingray</ship>
+  <ship>White Cat</ship>
+  <ship>Astro Robin</ship>
+  <ship>Death Anchor</ship>
+  <ship>Panzer Emerald</ship>
+  <ship>Red Gazelle</ship>
+  <ship>Iron Tiger</ship>
+  <ship>Deep Claw</ship>
+  <ship>Crazy Bear</ship>
+  <ship>Big Fang</ship>
+  <ship>Mad Wolf</ship>
+  <ship>Wonder Wasp</ship>
+  <ship>Wild Boar</ship>
+  <ship>Super Piranha</ship>
+  <ship>Mighty Hurricane</ship>
+  <ship>Space Angler</ship>
+  <ship>Mighty Typhoon</ship>
+  <ship>Green Panther</ship>
+  <ship>Blood Hawk</ship>
+  <ship>Black Bull</ship>
+  <ship>Great Star</ship>
+  <ship>Twin Noritta</ship>
+  <ship>Queen Meteor</ship>
+  <ship>Little Wyvern</ship>
+  <ship>King Meteor</ship>
+  <ship>Hyper Speeder</ship>
+  <ship>Night Thunder</ship>
+  <ship>Sonic Phantom</ship>
+  <ship>Elegance Liberty</ship>
+  <ship>Moon Shadow</ship>
  </ships>
 </game>

--- a/data/ladders/ladder14.xml
+++ b/data/ladders/ladder14.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
  <ladder_name>Climax Zero Test</ladder_name>
- <description>&lt;ul&gt;&lt;li&gt;Submit your Climax Zero Test times on this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;The same general Climax &lt;a href="/viewtopic.php?t=824"&gt;rules&lt;/a&gt; apply to this ladder&lt;/li&gt;&lt;li&gt;This Ladder does not count towards your championship ladder rank&lt;/li&gt;&lt;/ul&gt;</description>
+ <description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=climax" target="_blank"&gt;Time Submission Rules&lt;/a&gt; &lt;b&gt;(ESPECIALLY IF USING EMULATOR)&lt;/b&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;This Ladder does not count towards your championship ladder rank&lt;/li&gt;&lt;/ul&gt;</description>
  <hasspeed>No</hasspeed>
  <haslap>No</haslap>
  <hassettings>No</hassettings>
@@ -9,7 +9,7 @@
 <graphics_available>Yes</graphics_available>
   <palpossible>No</palpossible>
  <cups>
-  <cup cupid="1">   
+  <cup cupid="1">
    <cupname>Class C</cupname>
    <courses>
  <course courseid="1">
@@ -41,7 +41,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="2">   
+  <cup cupid="2">
    <cupname>Class B</cupname>
    <courses>
  <course courseid="1">
@@ -73,7 +73,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="3">   
+  <cup cupid="3">
    <cupname>Class A</cupname>
    <courses>
  <course courseid="1">
@@ -105,7 +105,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="4">   
+  <cup cupid="4">
       <cupname>Class S</cupname>
    <courses>
  <course courseid="1">
@@ -139,45 +139,45 @@
   </cup>
  </cups>
  <ships>
-  <ship>Dragon Bird Ex</ship> 
-  <ship>Mad Wolf</ship> 
-  <ship>Space Angler</ship> 
-  <ship>Night Thunder</ship> 
-  <ship>Red Gazelle</ship> 
-  <ship>Mighty Typhoon</ship> 
-  <ship>Mighty Hurricane</ship> 
-  <ship>Queen Meteor</ship> 
-  <ship>King Meteor</ship> 
-  <ship>Super Piranha</ship> 
-  <ship>Wonder Wasp</ship> 
-  <ship>Great Star</ship> 
-  <ship>Crazy Bear</ship> 
-  <ship>Elegance Liberty</ship> 
-  <ship>Astro Robin</ship> 
-  <ship>White Cat</ship> 
-  <ship>Golden Fox</ship> 
-  <ship>Dragon Bird</ship> 
-  <ship>Blue Falcon</ship> 
-  <ship>Blue Falcon 2</ship> 
-  <ship>Red Bull</ship> 
-  <ship>Wild Goose</ship> 
-  <ship>Fire Stingray</ship> 
-  <ship>Panzer Emerald</ship> 
-  <ship>Death Anchor</ship> 
-  <ship>Hyper Death Anchor</ship> 
-  <ship>Deep Claw</ship> 
-  <ship>Big Fang</ship> 
-  <ship>Moon Shadow</ship> 
-  <ship>Sonic Phantom</ship> 
-  <ship>Iron Tiger</ship> 
-  <ship>Green Panther</ship> 
-  <ship>Wild Boar</ship> 
-  <ship>Twin Noritta</ship> 
-  <ship>Soldier Anchor</ship> 
-  <ship>Blood Hawk</ship> 
-  <ship>Black Bull</ship> 
-  <ship>Hyper Speeder</ship> 
-  <ship>Little Wyvern</ship> 
+  <ship>Dragon Bird Ex</ship>
+  <ship>Mad Wolf</ship>
+  <ship>Space Angler</ship>
+  <ship>Night Thunder</ship>
+  <ship>Red Gazelle</ship>
+  <ship>Mighty Typhoon</ship>
+  <ship>Mighty Hurricane</ship>
+  <ship>Queen Meteor</ship>
+  <ship>King Meteor</ship>
+  <ship>Super Piranha</ship>
+  <ship>Wonder Wasp</ship>
+  <ship>Great Star</ship>
+  <ship>Crazy Bear</ship>
+  <ship>Elegance Liberty</ship>
+  <ship>Astro Robin</ship>
+  <ship>White Cat</ship>
+  <ship>Golden Fox</ship>
+  <ship>Dragon Bird</ship>
+  <ship>Blue Falcon</ship>
+  <ship>Blue Falcon 2</ship>
+  <ship>Red Bull</ship>
+  <ship>Wild Goose</ship>
+  <ship>Fire Stingray</ship>
+  <ship>Panzer Emerald</ship>
+  <ship>Death Anchor</ship>
+  <ship>Hyper Death Anchor</ship>
+  <ship>Deep Claw</ship>
+  <ship>Big Fang</ship>
+  <ship>Moon Shadow</ship>
+  <ship>Sonic Phantom</ship>
+  <ship>Iron Tiger</ship>
+  <ship>Green Panther</ship>
+  <ship>Wild Boar</ship>
+  <ship>Twin Noritta</ship>
+  <ship>Soldier Anchor</ship>
+  <ship>Blood Hawk</ship>
+  <ship>Black Bull</ship>
+  <ship>Hyper Speeder</ship>
+  <ship>Little Wyvern</ship>
  </ships>
  <platforms>
   <platform>GBA</platform>

--- a/data/ladders/ladder15.xml
+++ b/data/ladders/ladder15.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
 <ladder_name>Climax Survival</ladder_name>
-<description>&lt;ul&gt;&lt;li&gt;Submit your Climax Survival Mode times on this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;The same general Climax &lt;a href="/viewtopic.php?t=824"&gt;rules&lt;/a&gt; apply to this ladder&lt;/li&gt;&lt;li&gt;This Ladder does not count towards your championship ladder rank&lt;/li&gt;&lt;/ul&gt;</description>
+<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=climax" target="_blank"&gt;Time Submission Rules&lt;/a&gt; &lt;b&gt;(ESPECIALLY IF USING EMULATOR)&lt;/b&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;This Ladder does not count towards your championship ladder rank&lt;/li&gt;&lt;/ul&gt;</description>
 <hasspeed>No</hasspeed>
 <haslap>No</haslap>
 <hassettings>No</hassettings>
@@ -9,7 +9,7 @@
 <graphics_available>Yes</graphics_available>
 <palpossible>No</palpossible>
 <cups>
-	<cup cupid="1">   
+	<cup cupid="1">
 		<cupname>Tour</cupname>
 		<courses>
 			<course courseid="1">
@@ -17,7 +17,7 @@
 			</course>
 		</courses>
 	</cup>
-	<cup cupid="2">   
+	<cup cupid="2">
 		<cupname>Challenge</cupname>
 		<courses>
 			<course courseid="1">
@@ -25,7 +25,7 @@
 			</course>
 		</courses>
 	</cup>
-	<cup cupid="3">   
+	<cup cupid="3">
 		<cupname>Battle</cupname>
 		<courses>
 			<course courseid="1">
@@ -33,7 +33,7 @@
 			</course>
 		</courses>
 	</cup>
-	<cup cupid="4">   
+	<cup cupid="4">
 		<cupname>Violence</cupname>
 		<courses>
 			<course courseid="1">

--- a/data/ladders/ladder16.xml
+++ b/data/ladders/ladder16.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <game>
 <ladder_name>Expansion Kit</ladder_name>
-<description><ul><li>Please read the <a href="/viewtopic.php?t=826">Time Submission Rules</a> before submitting your times to this ladder.</li><li>Any track without a time will be given a default Ferris Beuller time for the total calculations.</li></ul></description>
+<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=x" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;All European PAL times are converted to NTSC using the formula NTSC = (PAL / 6) * 5 and the converse PAL = (NTSC * 6) / 5&lt;/li&gt;&lt;/ul&gt;</description>
 <hasspeed>Yes</hasspeed>
 <haslap>Yes</haslap>
 <hassettings>Yes</hassettings>

--- a/data/ladders/ladder17.xml
+++ b/data/ladders/ladder17.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <game>
 <ladder_name>X Death Race</ladder_name>
-	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/viewtopic.php?t=826"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;All European PAL times are converted to NTSC using the formula NTSC = (PAL / 6) * 5 and the converse PAL = (NTSC * 6) / 5&lt;/li&gt;&lt;/ul&gt;</description>
+	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=x" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;All European PAL times are converted to NTSC using the formula NTSC = (PAL / 6) * 5 and the converse PAL = (NTSC * 6) / 5&lt;/li&gt;&lt;/ul&gt;</description>
 <hasspeed>no</hasspeed>
 <haslap>no</haslap>
 <hassettings>no</hassettings>

--- a/data/ladders/ladder18.xml
+++ b/data/ladders/ladder18.xml
@@ -7,7 +7,7 @@
 
 
 
-  <description><ul><li>Please read the first post of <a href="/viewtopic.php?t=10192">This Topic</a> before submitting your times to this ladder.</li><li>Any track without a time will be given a default Ferris Beuller time for the total calculations.</li><li>All European PAL times are converted to NTSC using the formula NTSC = (PAL / 6) * 5 and the converse PAL = (NTSC * 6) / 5</li></ul></description>
+  <description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=x" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;All European PAL times are converted to NTSC using the formula NTSC = (PAL / 6) * 5 and the converse PAL = (NTSC * 6) / 5&lt;/li&gt;&lt;/ul&gt;</description>
 
 
 

--- a/data/ladders/ladder2.xml
+++ b/data/ladders/ladder2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
 	<ladder_name>X</ladder_name>
-	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/viewtopic.php?t=826"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;All European PAL times are converted to NTSC using the formula NTSC = (PAL / 6) * 5 and the converse PAL = (NTSC * 6) / 5&lt;/li&gt;&lt;/ul&gt;</description>
+	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=x" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;All European PAL times are converted to NTSC using the formula NTSC = (PAL / 6) * 5 and the converse PAL = (NTSC * 6) / 5&lt;/li&gt;&lt;/ul&gt;</description>
 	<hasspeed>Yes</hasspeed>
 	<haslap>Yes</haslap>
 	<hassettings>Yes</hassettings>
@@ -11,7 +11,7 @@
 	<pal_numerator>6</pal_numerator>
 	<pal_denominator>5</pal_denominator>
 	<cups>
-	<cup cupid="1">   
+	<cup cupid="1">
 	<cupname>Jack Cup</cupname>
 	<courses>
 	<course courseid="1">
@@ -34,7 +34,7 @@
 	</course>
 	</courses>
 	</cup>
-	<cup cupid="2">   
+	<cup cupid="2">
 	<cupname>Queen Cup</cupname>
 	<courses>
 	<course courseid="1">
@@ -57,7 +57,7 @@
 	</course>
 	</courses>
 	</cup>
-	<cup cupid="3">   
+	<cup cupid="3">
 	<cupname>King Cup</cupname>
 	<courses>
 	<course courseid="1">
@@ -80,7 +80,7 @@
 	</course>
 	</courses>
 	</cup>
-	<cup cupid="4">   
+	<cup cupid="4">
 	<cupname>Joker Cup</cupname>
 	<courses>
 	<course courseid="1">

--- a/data/ladders/ladder3.xml
+++ b/data/ladders/ladder3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
 	<ladder_name>Maximum Velocity</ladder_name>
-	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/viewtopic.php?t=188"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;/ul&gt;</description>
+	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=mv" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;/ul&gt;</description>
 	<hasspeed>No</hasspeed>
 	<haslap>Yes</haslap>
 	<hassettings>No</hassettings>
@@ -9,7 +9,7 @@
 	<palpossible>No</palpossible>
 	<graphics_available>Yes</graphics_available>
  <cups>
-  <cup cupid="1">   
+  <cup cupid="1">
    <cupname>Pawn Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -29,7 +29,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="2">   
+  <cup cupid="2">
    <cupname>Knight Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -49,7 +49,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="3">   
+  <cup cupid="3">
    <cupname>Bishop Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -69,7 +69,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="4">   
+  <cup cupid="4">
    <cupname>Queen Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -89,7 +89,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="5">   
+  <cup cupid="5">
    <cupname>Championship</cupname>
    <courses>
 	<course courseid="1">

--- a/data/ladders/ladder4.xml
+++ b/data/ladders/ladder4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
 	<ladder_name>GX Open</ladder_name>
-	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/viewtopic.php?t=13683"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;Always save proof - save a ghost and replay of your best times.&lt;/li&gt;&lt;li&gt;Don't cheat - but snaking and spaceflying ARE allowed in this ladder.&lt;/li&gt;&lt;/ul&gt;</description>
+	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=gx" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;Always save proof - save a ghost and replay of your best times.&lt;/li&gt;&lt;li&gt;Don't cheat - but snaking and spaceflying ARE allowed in this ladder.&lt;/li&gt;&lt;/ul&gt;</description>
 	<hasspeed>Yes</hasspeed>
 	<haslap>Yes</haslap>
 	<hassettings>Yes</hassettings>
@@ -9,7 +9,7 @@
 	<palpossible>No</palpossible>
 	<graphics_available>Yes</graphics_available>
  <cups>
-  <cup cupid="1">   
+  <cup cupid="1">
    <cupname>Ruby Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -29,7 +29,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="2">   
+  <cup cupid="2">
    <cupname>Sapphire Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -49,7 +49,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="3">   
+  <cup cupid="3">
    <cupname>Emerald Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -69,7 +69,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="4">   
+  <cup cupid="4">
    <cupname>Diamond Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -89,7 +89,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="5">   
+  <cup cupid="5">
    <cupname>AX Cup</cupname>
    <courses>
 	<course courseid="1">

--- a/data/ladders/ladder5.xml
+++ b/data/ladders/ladder5.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
 	<ladder_name>GX Max Speed</ladder_name>
-	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/viewtopic.php?t=13683"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;Always save proof - save a ghost and replay of your best times.&lt;/li&gt;&lt;li&gt;Don't cheat - snaking and spaceflying ARE NOT allowed in this ladder.&lt;/li&gt;&lt;li&gt;All times in this ladder must be set while at 100% Max Speed settings&lt;/li&gt;&lt;/ul&gt;</description>
+	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=gx" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;Always save proof - save a ghost and replay of your best times.&lt;/li&gt;&lt;li&gt;Don't cheat - snaking and spaceflying ARE NOT allowed in this ladder.&lt;/li&gt;&lt;li&gt;All times in this ladder must be set while at 100% Max Speed settings&lt;/li&gt;&lt;/ul&gt;</description>
 	<hasspeed>Yes</hasspeed>
 	<haslap>Yes</haslap>
 	<hassettings>Yes</hassettings>
@@ -9,7 +9,7 @@
 	<palpossible>No</palpossible>
 	<graphics_available>Yes</graphics_available>
  <cups>
-  <cup cupid="1">   
+  <cup cupid="1">
    <cupname>Ruby Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -29,7 +29,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="2">   
+  <cup cupid="2">
    <cupname>Sapphire Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -49,7 +49,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="3">   
+  <cup cupid="3">
    <cupname>Emerald Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -69,7 +69,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="4">   
+  <cup cupid="4">
    <cupname>Diamond Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -89,7 +89,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="5">   
+  <cup cupid="5">
    <cupname>AX Cup</cupname>
    <courses>
 	<course courseid="1">

--- a/data/ladders/ladder6.xml
+++ b/data/ladders/ladder6.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
 	<ladder_name>GP Legend</ladder_name>
-	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/viewtopic.php?t=174"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;/ul&gt;</description>
+	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=gpl" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;/ul&gt;</description>
 	<hasspeed>No</hasspeed>
 	<haslap>Yes</haslap>
 	<hassettings>No</hassettings>
@@ -9,7 +9,7 @@
 	<graphics_available>Yes</graphics_available>
 	<palpossible>No</palpossible>
  <cups>
-  <cup cupid="1">   
+  <cup cupid="1">
    <cupname>Bronze Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -44,7 +44,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="2">   
+  <cup cupid="2">
    <cupname>Silver Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -79,7 +79,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="3">   
+  <cup cupid="3">
    <cupname>Gold Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -120,7 +120,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="4">   
+  <cup cupid="4">
    <cupname>Platinum Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -149,7 +149,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="5">   
+  <cup cupid="5">
    <cupname>Championship</cupname>
    <courses>
 	<course courseid="1">

--- a/data/ladders/ladder7.xml
+++ b/data/ladders/ladder7.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
 	<ladder_name>Climax</ladder_name>
-	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/viewtopic.php?t=824"&gt;Time Submission Rules&lt;/a&gt; &lt;b&gt;(ESPECIALLY IF USING EMULATOR)&lt;/b&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;/ul&gt;</description>
+	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=climax" target="_blank"&gt;Time Submission Rules&lt;/a&gt; &lt;b&gt;(ESPECIALLY IF USING EMULATOR)&lt;/b&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;/ul&gt;</description>
 	<hasspeed>No</hasspeed>
 	<haslap>Yes</haslap>
 	<hassettings>No</hassettings>
@@ -10,7 +10,7 @@
 	<numtracks>54</numtracks>
 	<graphics_available>Yes</graphics_available>
  <cups>
-  <cup cupid="1">   
+  <cup cupid="1">
    <cupname>Bronze Cup</cupname>
    <courses>
  <course courseid="1">
@@ -60,7 +60,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="2">   
+  <cup cupid="2">
    <cupname>Silver Cup</cupname>
    <courses>
  <course courseid="1">
@@ -110,7 +110,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="3">   
+  <cup cupid="3">
    <cupname>Gold Cup</cupname>
    <courses>
  <course courseid="1">
@@ -160,7 +160,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="4">   
+  <cup cupid="4">
    <cupname>Platinum Cup</cupname>
    <courses>
  <course courseid="1">
@@ -189,7 +189,7 @@
     </course>
    </courses>
   </cup>
-<cup cupid="5">   
+<cup cupid="5">
    <cupname>Championship</cupname>
    <courses>
  <course courseid="1">

--- a/data/ladders/ladder8.xml
+++ b/data/ladders/ladder8.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <game>
 	<ladder_name>GX Snaking</ladder_name>
-	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/viewtopic.php?t=13683"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;Always save proof - save a ghost and replay of your best times.&lt;/li&gt;&lt;li&gt;Don't cheat - spaceflying is NOT allowed in this ladder.&lt;/li&gt;&lt;li&gt;All times in this ladder must be set while at 0% settings&lt;/li&gt;&lt;li&gt;</description>
+	<description>&lt;ul&gt;&lt;li&gt;Please read the &lt;a href="/rules.php?game=gx" target="_blank"&gt;Time Submission Rules&lt;/a&gt; before submitting your times to this ladder.&lt;/li&gt;&lt;li&gt;Any track without a time will be given a default Ferris Beuller time for the total calculations.&lt;/li&gt;&lt;li&gt;Always save proof - save a ghost and replay of your best times.&lt;/li&gt;&lt;li&gt;Don't cheat - spaceflying is NOT allowed in this ladder.&lt;/li&gt;&lt;li&gt;All times in this ladder must be set while at 0% settings&lt;/li&gt;&lt;li&gt;</description>
 	<hasspeed>Yes</hasspeed>
 	<haslap>Yes</haslap>
 	<hassettings>Yes</hassettings>
@@ -9,7 +9,7 @@
 	<palpossible>No</palpossible>
 	<graphics_available>Yes</graphics_available>
  <cups>
-  <cup cupid="1">   
+  <cup cupid="1">
    <cupname>Ruby Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -29,7 +29,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="2">   
+  <cup cupid="2">
    <cupname>Sapphire Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -49,7 +49,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="3">   
+  <cup cupid="3">
    <cupname>Emerald Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -69,7 +69,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="4">   
+  <cup cupid="4">
    <cupname>Diamond Cup</cupname>
    <courses>
 	<course courseid="1">
@@ -89,7 +89,7 @@
     </course>
    </courses>
   </cup>
-  <cup cupid="5">   
+  <cup cupid="5">
    <cupname>AX Cup</cupname>
    <courses>
 	<course courseid="1">

--- a/public/fzero.css
+++ b/public/fzero.css
@@ -1081,7 +1081,7 @@ div.ladder-leaders > div > div > span {
   margin: 0px auto;
 }
 
-.page-rules .rules-text {
+.page-rules .rules-content {
   background-color: hsl(0, 0%, 90%);
   padding: 20px;
   border-radius: 20px;

--- a/public/fzero.css
+++ b/public/fzero.css
@@ -271,12 +271,12 @@ div.postbody_root, div.postbody_reply {
 	color: black;
 	font-family: "Verdana", "Courier New", Arial, Helvetica, sans-serif;
 	background-color : #F7F7F7;
-	
+
 	display: flex;
 	flex-direction: column;
 	/* Allow absolute positioning of adminbars relative to this postbody */
 	position: relative;
-	
+
 	padding: 12px 35px 28px 35px;
 	border-radius: 8px;
 }
@@ -334,10 +334,10 @@ div.post_main_column {
 
 div.post_info {
   flex-grow: 1;
-  
+
   display: flex;
   flex-direction: column;
-  
+
 	font-size:  8pt;
 	white-space: nowrap;
 	text-align: right;
@@ -392,10 +392,10 @@ div.post_part_nt {			/* hide user info for empty posts */
 #mfomenu {
   display: flex;
   flex-wrap: wrap;
-  
+
   margin: 10px;
   padding: 0;
-  
+
   /* Make the menus pop over the other header stuff, not under */
   z-index: 1;
   /* Ensure the z-index is passed to descendants */
@@ -415,10 +415,10 @@ div.post_part_nt {			/* hide user info for empty posts */
 
 #mfomenu li ul {
   display: none;
-  
+
   /* Don't push other elements when a sub-menu pops up */
   position: absolute;
-  
+
   white-space: nowrap;
   background-color: #000033;
   padding: 0.5em 0;
@@ -457,7 +457,7 @@ div.adminbar {
   to move between the left and right sides. JS also determines the position
   from top. */
   left: 0px;
-  
+
   /* Hidden by default; Javascript will un-hide for admin users */
   visibility: hidden;
   white-space: nowrap;
@@ -748,7 +748,7 @@ div.home-page-box-body, div.home-page-box-without-header {
   background-color: white;
   font-family: Verdana;
   font-size: 0.8em;
-  
+
   padding: 8px;
   box-shadow: 4px 4px 8px 0 hsla(0, -1%, -1%, 0.6);
 }
@@ -792,7 +792,7 @@ div.home-page-ladders-text {
 div.home-page-ladder-group > div.body {
   /* Hide until hover. This makes the menus basically inaccessible on mobile,
   but in this case it's not the worst thing ever because you can still access
-  individual ladders from ladderhome. */ 
+  individual ladders from ladderhome. */
   display: none;
   /* Pop-over menu; don't push other elements. */
   position: absolute;
@@ -800,7 +800,7 @@ div.home-page-ladder-group > div.body {
   z-index: 1;
   /* Position at bottom of parent element. */
   top: 100%;
-  
+
   padding: 3px 12px;
 }
 div.home-page-ladder-group:hover,
@@ -1079,4 +1079,10 @@ div.ladder-leaders > div > div > span {
 .page-ladder .main-content {
   max-width: 960px;
   margin: 0px auto;
+}
+
+.page-rules .rules-text {
+  background-color: hsl(0, 0%, 90%);
+  padding: 20px;
+  border-radius: 20px;
 }

--- a/public/guidelines.php
+++ b/public/guidelines.php
@@ -1,0 +1,9 @@
+<?php
+
+require_once '../common.php';
+
+$template = $twig->load('rules/guidelines.html');
+echo $template->render([
+  'page_class' => 'page-rules',
+  'PAGE_TITLE' => 'Ladder guidelines',
+]);

--- a/public/rules.php
+++ b/public/rules.php
@@ -1,0 +1,12 @@
+<?php
+
+require_once '../common.php';
+
+$game_shortcode = $_GET['game'];
+$game = FserverGame($game_shortcode);
+
+$template = $twig->load($game->rules_template);
+echo $template->render([
+  'page_class' => 'page-rules',
+  'PAGE_TITLE' => $game->name . " time submission rules",
+]);

--- a/src/fzero.php
+++ b/src/fzero.php
@@ -105,6 +105,13 @@ function ship_image_url($ship_name) {
   return "/images/ships/$ship_filename";
 }
 
+function FserverGame($game_shortcode) {
+  $file = __DIR__ . "/../data/games/$game_shortcode.xml";
+  $game = simplexml_load_file($file);
+
+  return $game;
+}
+
 function FserverLadder($ladder_id) {
   $file = __DIR__ . "/../data/ladders/ladder$ladder_id.xml";
   $ladder = simplexml_load_file($file);

--- a/templates/rules/base.html
+++ b/templates/rules/base.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <div class=rules-content>
+    {% block rules_content %}{% endblock %}
+  </div>
+{% endblock %}

--- a/templates/rules/climax.html
+++ b/templates/rules/climax.html
@@ -1,137 +1,135 @@
-{% extends 'base.html' %}
+{% extends 'rules/base.html' %}
 
-{% block content %}
-<div class=rules-text>
-  <p style=text-align:center>
-    <strong>
-      <span style=font-size:xx-large>
-        <span style=font-family:Arial>F-Zero Central F-ZERO Climax Time Submission Rules</span>
-      </span>
-    </strong>
-  </p>
-  <p>
-    <span style=font-family:Arial></span>
-  </p>
-  <p align=center>
-    <span style=font-family:Arial>Last Updated: 23rd March 2021</span>
-  </p>
-  <hr>
-  <p style=text-align:center>
+{% block rules_content %}
+<p style=text-align:center>
+  <strong>
+    <span style=font-size:xx-large>
+      <span style=font-family:Arial>F-Zero Central F-ZERO Climax Time Submission Rules</span>
+    </span>
+  </strong>
+</p>
+<p>
+  <span style=font-family:Arial></span>
+</p>
+<p align=center>
+  <span style=font-family:Arial>Last Updated: 23rd March 2021</span>
+</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <font size=5>Basic Ladder Rules</font>
+  </span>
+</p>
+<p>
+  <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</span>
+</p>
+<p>
+  <span style=font-family:Arial>2. FZC accepts times set with the game cartridge, Flash cartridge ("Flashcart") with an unaltered ROM of the original game and the Wii U Virtual Console using the standard rules for all games. Emulators are allowed in this game due to the fact it is very hard to obtain the game cartridge these days due to it's original limited release but need an additional set of rules to ensure people playing under these conditions have a setup as close as possible to people playing with Official Releases. see Emulator Rules below for a detailed explanation of the rules applying to Emulator users.</span>
+</p>
+<p>
+  <span style=font-family:Arial>3. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for teams. Only submit times that are shown on your records screen.</span>
+</p>
+<p>
+  <span style=font-family:Arial>4. The use of cheat devices such as Action Replay are forbidden on the ladder. Restore points on the Wii U VC or save-states for mGBA are not to be misused. See Save State Rules below for a detailed explaination. <br>
+    <br> 5. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff. </span>
+</p>
+<p>
+  <span style=font-family:Arial>6. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
+</p>
+<p>
+  <span style=font-family:Arial>7. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
+</p>
+<hr>
+<p style=text-align:center>
+  <font size=5>F-Zero Climax Emulator Rules</font>
+</p>
+<p>Because of the nature of unofficial Emulators, some extra rules are needed to allow times set when using them and prevent abuse or cheating as much as possible.</p>
+<p>The following are rules to be followed when setting times in F-Zero Climax while playing on emulator:</p>
+<p>- The only allowed emulator as of right now is mGBA desktop version 0.8.x. If a new major version comes out it will first be investigated before being accepted. <br> - Video proof must capture the entire emulator window, including the title bar which shows the FPS and version number. you are allowed to rearrange the screen layout but there must be at least one window showing the requested information unaltered. <br> - Video proof is required for top 10 times and the video must be linked in the Video Link field of your submission. videos don't have a limit in quality and at minimum should be recorded using the GBA's native resolution (240x160) and framerate. <br> - The game must run at full speed at all times. if your computer experiences slowdowns from having many programs open at once, close them until the emulator runs well. If the video causes the slowdown, lower video quality until there's no slowdown. <br> - You must choose "mGBA [version used]" in the Platform field of your submission. </p>
+<p>And furthermore, instructions for setting up the emulator: <br> 1. Download and install an allowed version of mGBA at <a href=https://mgba.io/downloads.html>https://mgba.io/downloads.html</a>
+  <br> 2. By default all settings are correct, but ensure the following: <br> - Frameskip is set to 0 <br> - Ensure cheats are disabled / there are no cheats loaded <br> - Do not bind autofire to prevent accidental use <br> - FPS target should be "Native (59.7275)" <br> 3 (Optional). If you want to use an existing save data with everything unlocked, you can download the following file and place it in the same folder as your ROM with the same name as your ROM <a href="https://drive.google.com/file/d/16BbTwqw1vAPY2U8EUfa3ueQ0g-h2BJOz/view?usp=sharing">https://drive.google.com/file/d/16BbTwqw1vAPY2U8EUfa3ueQ0g-h2BJOz/view?usp=sharing</a>
+</p>
+<hr>
+<p style=text-align:center>
+  <font size=5>Save State Rules for Runs Submitted to Ladder <br>
+  </font>
+</p>
+<p>When submitting runs to the FZC ladder, save states or restore points may only be used as described below. If save states/restore points are used anywhere else other than as described below, the player doing so will have their associated time removed. <br>
+  <br> 3-Laps <br>
+  <br> Before the countdown of the 3-lap attempt first starts. <br>
+  <br> Fast Laps <br>
+  <br> Before exceeding 1200km/h, not while in boost state and before entering the Fast Lap.
+</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+  </span>
+</p>
+<p>
+  <span style=font-size:small></span>
+</p>
+<p style=text-align:center>
+  <span style=font-family:Arial>&nbsp; To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof. If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*.</span>
+</p>
+<p>
+  <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
+</p>
+<ol>
+  <li>
+    <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
+  </li>
+  <li>
+    <span style=font-family:Arial>The video must display the ending stats from the race after it is over.</span>
+  </li>
+  <li>
+    <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
+  </li>
+  <li>
     <span style=font-family:Arial>
-      <font size=5>Basic Ladder Rules</font>
+      <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any to see, FZC reserves the right to take down your time associated with that video.</span>
     </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>2. FZC accepts times set with the game cartridge, Flash cartridge ("Flashcart") with an unaltered ROM of the original game and the Wii U Virtual Console using the standard rules for all games. Emulators are allowed in this game due to the fact it is very hard to obtain the game cartridge these days due to it's original limited release but need an additional set of rules to ensure people playing under these conditions have a setup as close as possible to people playing with Official Releases. see Emulator Rules below for a detailed explanation of the rules applying to Emulator users.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>3. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for teams. Only submit times that are shown on your records screen.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>4. The use of cheat devices such as Action Replay are forbidden on the ladder. Restore points on the Wii U VC or save-states for mGBA are not to be misused. See Save State Rules below for a detailed explaination. <br>
-      <br> 5. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff. </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>6. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>7. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
-  </p>
-  <hr>
-  <p style=text-align:center>
-    <font size=5>F-Zero Climax Emulator Rules</font>
-  </p>
-  <p>Because of the nature of unofficial Emulators, some extra rules are needed to allow times set when using them and prevent abuse or cheating as much as possible.</p>
-  <p>The following are rules to be followed when setting times in F-Zero Climax while playing on emulator:</p>
-  <p>- The only allowed emulator as of right now is mGBA desktop version 0.8.x. If a new major version comes out it will first be investigated before being accepted. <br> - Video proof must capture the entire emulator window, including the title bar which shows the FPS and version number. you are allowed to rearrange the screen layout but there must be at least one window showing the requested information unaltered. <br> - Video proof is required for top 10 times and the video must be linked in the Video Link field of your submission. videos don't have a limit in quality and at minimum should be recorded using the GBA's native resolution (240x160) and framerate. <br> - The game must run at full speed at all times. if your computer experiences slowdowns from having many programs open at once, close them until the emulator runs well. If the video causes the slowdown, lower video quality until there's no slowdown. <br> - You must choose "mGBA [version used]" in the Platform field of your submission. </p>
-  <p>And furthermore, instructions for setting up the emulator: <br> 1. Download and install an allowed version of mGBA at <a href=https://mgba.io/downloads.html>https://mgba.io/downloads.html</a>
-    <br> 2. By default all settings are correct, but ensure the following: <br> - Frameskip is set to 0 <br> - Ensure cheats are disabled / there are no cheats loaded <br> - Do not bind autofire to prevent accidental use <br> - FPS target should be "Native (59.7275)" <br> 3 (Optional). If you want to use an existing save data with everything unlocked, you can download the following file and place it in the same folder as your ROM with the same name as your ROM <a href="https://drive.google.com/file/d/16BbTwqw1vAPY2U8EUfa3ueQ0g-h2BJOz/view?usp=sharing">https://drive.google.com/file/d/16BbTwqw1vAPY2U8EUfa3ueQ0g-h2BJOz/view?usp=sharing</a>
-  </p>
-  <hr>
-  <p style=text-align:center>
-    <font size=5>Save State Rules for Runs Submitted to Ladder <br>
-    </font>
-  </p>
-  <p>When submitting runs to the FZC ladder, save states or restore points may only be used as described below. If save states/restore points are used anywhere else other than as described below, the player doing so will have their associated time removed. <br>
-    <br> 3-Laps <br>
-    <br> Before the countdown of the 3-lap attempt first starts. <br>
-    <br> Fast Laps <br>
-    <br> Before exceeding 1200km/h, not while in boost state and before entering the Fast Lap.
-  </p>
-  <hr>
-  <p style=text-align:center>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
-    </span>
-  </p>
-  <p>
-    <span style=font-size:small></span>
-  </p>
-  <p style=text-align:center>
-    <span style=font-family:Arial>&nbsp; To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof. If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
-  </p>
-  <ol>
-    <li>
-      <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
-    </li>
-    <li>
-      <span style=font-family:Arial>The video must display the ending stats from the race after it is over.</span>
-    </li>
-    <li>
-      <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
-    </li>
-    <li>
-      <span style=font-family:Arial>
-        <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any to see, FZC reserves the right to take down your time associated with that video.</span>
-      </span>
-    </li>
-  </ol>
-  <p>
-    <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
-  </p>
-  <hr>
-  <p style=text-align:center>&nbsp; <span style=font-size:x-large;font-family:Arial;background-color:rgb(247,247,247);text-align:center>F-Zero Central Ladder Guidelines</span>
-  </p>
-  <p style=background-color:rgb(247,247,247)>
-    <font face=Arial>
-      <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
-    </font>
-    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
-      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-    </a>
-  </p>
-  <hr>
-  <p style=background-color:rgb(247,247,247)>
-    <strong>
-      <span style=font-family:Arial>-UPDATES-</span>
-    </strong>
-  </p>
-  <p style=background-color:rgb(247,247,247)>
-    <strong>
-      <span style=font-family:Arial> 30th August 2020</span>
-    </strong>
-    <span style=font-family:Arial>: <br> Updated the rules for usage of save states/restore points.You must now add your save state/restore point before the countdown of the 3-lap attempt first starts, and for fast-laps before exceeding 1200km/h, not while in boost state and before entering the Fast-Lap. A topic for the discussion can be found <a href="https://fzerocentral.org/viewtopic.php?t=14381" target=_blank>here</a>.
-    </span>
-  </p>
-  <p style=background-color:rgb(247,247,247)>
-    <strong>
-      <span style=font-family:Arial>6th September 2020</span>
-    </strong>
-    <span style=font-family:Arial>: <br> The emulator proof rules have been changed to use the newly available Platform and Video Link fields. <a href="https://fzerocentral.org/viewtopic.php?t=14382">Thread</a>
-      <br>
-    </span>
-  </p>
-  <p style=background-color:rgb(247,247,247)>
-    <strong>
-      <span style=font-family:Arial>23rd March 2021</span>
-    </strong>
-    <span style=font-family:Arial>: <br> added Flashcarts to the rules. </span>
-  </p>
-</div>
+  </li>
+</ol>
+<p>
+  <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
+</p>
+<hr>
+<p style=text-align:center>&nbsp; <span style=font-size:x-large;font-family:Arial;background-color:rgb(247,247,247);text-align:center>F-Zero Central Ladder Guidelines</span>
+</p>
+<p style=background-color:rgb(247,247,247)>
+  <font face=Arial>
+    <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
+  </font>
+  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
+    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+  </a>
+</p>
+<hr>
+<p style=background-color:rgb(247,247,247)>
+  <strong>
+    <span style=font-family:Arial>-UPDATES-</span>
+  </strong>
+</p>
+<p style=background-color:rgb(247,247,247)>
+  <strong>
+    <span style=font-family:Arial> 30th August 2020</span>
+  </strong>
+  <span style=font-family:Arial>: <br> Updated the rules for usage of save states/restore points.You must now add your save state/restore point before the countdown of the 3-lap attempt first starts, and for fast-laps before exceeding 1200km/h, not while in boost state and before entering the Fast-Lap. A topic for the discussion can be found <a href="https://fzerocentral.org/viewtopic.php?t=14381" target=_blank>here</a>.
+  </span>
+</p>
+<p style=background-color:rgb(247,247,247)>
+  <strong>
+    <span style=font-family:Arial>6th September 2020</span>
+  </strong>
+  <span style=font-family:Arial>: <br> The emulator proof rules have been changed to use the newly available Platform and Video Link fields. <a href="https://fzerocentral.org/viewtopic.php?t=14382">Thread</a>
+    <br>
+  </span>
+</p>
+<p style=background-color:rgb(247,247,247)>
+  <strong>
+    <span style=font-family:Arial>23rd March 2021</span>
+  </strong>
+  <span style=font-family:Arial>: <br> added Flashcarts to the rules. </span>
+</p>
 {% endblock %}

--- a/templates/rules/climax.html
+++ b/templates/rules/climax.html
@@ -95,30 +95,27 @@
   <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
 </p>
 <hr>
-<p style=text-align:center>&nbsp; <span style=font-size:x-large;font-family:Arial;background-color:rgb(247,247,247);text-align:center>F-Zero Central Ladder Guidelines</span>
+<p style=text-align:center>&nbsp; <span style=font-size:x-large;font-family:Arial;text-align:center>F-Zero Central Ladder Guidelines</span>
 </p>
-<p style=background-color:rgb(247,247,247)>
-  <font face=Arial>
-    <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
-  </font>
-  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
-    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-  </a>
+<p>
+  <span style=font-family:Arial>
+    <a href="/guidelines.php" target=_blank>Read here</a> - these are not enforceable rules, but guidelines for all players to follow.
+  </span>
 </p>
 <hr>
-<p style=background-color:rgb(247,247,247)>
+<p>
   <strong>
     <span style=font-family:Arial>-UPDATES-</span>
   </strong>
 </p>
-<p style=background-color:rgb(247,247,247)>
+<p>
   <strong>
     <span style=font-family:Arial> 30th August 2020</span>
   </strong>
   <span style=font-family:Arial>: <br> Updated the rules for usage of save states/restore points.You must now add your save state/restore point before the countdown of the 3-lap attempt first starts, and for fast-laps before exceeding 1200km/h, not while in boost state and before entering the Fast-Lap. A topic for the discussion can be found <a href="https://fzerocentral.org/viewtopic.php?t=14381" target=_blank>here</a>.
   </span>
 </p>
-<p style=background-color:rgb(247,247,247)>
+<p>
   <strong>
     <span style=font-family:Arial>6th September 2020</span>
   </strong>
@@ -126,7 +123,7 @@
     <br>
   </span>
 </p>
-<p style=background-color:rgb(247,247,247)>
+<p>
   <strong>
     <span style=font-family:Arial>23rd March 2021</span>
   </strong>

--- a/templates/rules/climax.html
+++ b/templates/rules/climax.html
@@ -1,0 +1,137 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class=rules-text>
+  <p style=text-align:center>
+    <strong>
+      <span style=font-size:xx-large>
+        <span style=font-family:Arial>F-Zero Central F-ZERO Climax Time Submission Rules</span>
+      </span>
+    </strong>
+  </p>
+  <p>
+    <span style=font-family:Arial></span>
+  </p>
+  <p align=center>
+    <span style=font-family:Arial>Last Updated: 23rd March 2021</span>
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <font size=5>Basic Ladder Rules</font>
+    </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>2. FZC accepts times set with the game cartridge, Flash cartridge ("Flashcart") with an unaltered ROM of the original game and the Wii U Virtual Console using the standard rules for all games. Emulators are allowed in this game due to the fact it is very hard to obtain the game cartridge these days due to it's original limited release but need an additional set of rules to ensure people playing under these conditions have a setup as close as possible to people playing with Official Releases. see Emulator Rules below for a detailed explanation of the rules applying to Emulator users.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>3. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for teams. Only submit times that are shown on your records screen.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>4. The use of cheat devices such as Action Replay are forbidden on the ladder. Restore points on the Wii U VC or save-states for mGBA are not to be misused. See Save State Rules below for a detailed explaination. <br>
+      <br> 5. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff. </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>6. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>7. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <font size=5>F-Zero Climax Emulator Rules</font>
+  </p>
+  <p>Because of the nature of unofficial Emulators, some extra rules are needed to allow times set when using them and prevent abuse or cheating as much as possible.</p>
+  <p>The following are rules to be followed when setting times in F-Zero Climax while playing on emulator:</p>
+  <p>- The only allowed emulator as of right now is mGBA desktop version 0.8.x. If a new major version comes out it will first be investigated before being accepted. <br> - Video proof must capture the entire emulator window, including the title bar which shows the FPS and version number. you are allowed to rearrange the screen layout but there must be at least one window showing the requested information unaltered. <br> - Video proof is required for top 10 times and the video must be linked in the Video Link field of your submission. videos don't have a limit in quality and at minimum should be recorded using the GBA's native resolution (240x160) and framerate. <br> - The game must run at full speed at all times. if your computer experiences slowdowns from having many programs open at once, close them until the emulator runs well. If the video causes the slowdown, lower video quality until there's no slowdown. <br> - You must choose "mGBA [version used]" in the Platform field of your submission. </p>
+  <p>And furthermore, instructions for setting up the emulator: <br> 1. Download and install an allowed version of mGBA at <a href=https://mgba.io/downloads.html>https://mgba.io/downloads.html</a>
+    <br> 2. By default all settings are correct, but ensure the following: <br> - Frameskip is set to 0 <br> - Ensure cheats are disabled / there are no cheats loaded <br> - Do not bind autofire to prevent accidental use <br> - FPS target should be "Native (59.7275)" <br> 3 (Optional). If you want to use an existing save data with everything unlocked, you can download the following file and place it in the same folder as your ROM with the same name as your ROM <a href="https://drive.google.com/file/d/16BbTwqw1vAPY2U8EUfa3ueQ0g-h2BJOz/view?usp=sharing">https://drive.google.com/file/d/16BbTwqw1vAPY2U8EUfa3ueQ0g-h2BJOz/view?usp=sharing</a>
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <font size=5>Save State Rules for Runs Submitted to Ladder <br>
+    </font>
+  </p>
+  <p>When submitting runs to the FZC ladder, save states or restore points may only be used as described below. If save states/restore points are used anywhere else other than as described below, the player doing so will have their associated time removed. <br>
+    <br> 3-Laps <br>
+    <br> Before the countdown of the 3-lap attempt first starts. <br>
+    <br> Fast Laps <br>
+    <br> Before exceeding 1200km/h, not while in boost state and before entering the Fast Lap.
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+    </span>
+  </p>
+  <p>
+    <span style=font-size:small></span>
+  </p>
+  <p style=text-align:center>
+    <span style=font-family:Arial>&nbsp; To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof. If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
+  </p>
+  <ol>
+    <li>
+      <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
+    </li>
+    <li>
+      <span style=font-family:Arial>The video must display the ending stats from the race after it is over.</span>
+    </li>
+    <li>
+      <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
+    </li>
+    <li>
+      <span style=font-family:Arial>
+        <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any to see, FZC reserves the right to take down your time associated with that video.</span>
+      </span>
+    </li>
+  </ol>
+  <p>
+    <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
+  </p>
+  <hr>
+  <p style=text-align:center>&nbsp; <span style=font-size:x-large;font-family:Arial;background-color:rgb(247,247,247);text-align:center>F-Zero Central Ladder Guidelines</span>
+  </p>
+  <p style=background-color:rgb(247,247,247)>
+    <font face=Arial>
+      <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
+    </font>
+    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
+      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+    </a>
+  </p>
+  <hr>
+  <p style=background-color:rgb(247,247,247)>
+    <strong>
+      <span style=font-family:Arial>-UPDATES-</span>
+    </strong>
+  </p>
+  <p style=background-color:rgb(247,247,247)>
+    <strong>
+      <span style=font-family:Arial> 30th August 2020</span>
+    </strong>
+    <span style=font-family:Arial>: <br> Updated the rules for usage of save states/restore points.You must now add your save state/restore point before the countdown of the 3-lap attempt first starts, and for fast-laps before exceeding 1200km/h, not while in boost state and before entering the Fast-Lap. A topic for the discussion can be found <a href="https://fzerocentral.org/viewtopic.php?t=14381" target=_blank>here</a>.
+    </span>
+  </p>
+  <p style=background-color:rgb(247,247,247)>
+    <strong>
+      <span style=font-family:Arial>6th September 2020</span>
+    </strong>
+    <span style=font-family:Arial>: <br> The emulator proof rules have been changed to use the newly available Platform and Video Link fields. <a href="https://fzerocentral.org/viewtopic.php?t=14382">Thread</a>
+      <br>
+    </span>
+  </p>
+  <p style=background-color:rgb(247,247,247)>
+    <strong>
+      <span style=font-family:Arial>23rd March 2021</span>
+    </strong>
+    <span style=font-family:Arial>: <br> added Flashcarts to the rules. </span>
+  </p>
+</div>
+{% endblock %}

--- a/templates/rules/gpl.html
+++ b/templates/rules/gpl.html
@@ -1,0 +1,109 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class=rules-text>
+  <p align=center>
+    <span style=font-family:Arial>
+      <span style=font-size:xx-large>
+        <strong>F-Zero Central F-ZERO GP Legend Time Submission Rules</strong>
+      </span>
+    </span>
+  </p>
+  <p>
+    <span style=font-family:Arial></span>
+  </p>
+  <p align=center>
+    <span style=font-family:Arial>Last Updated: 23 Mar 2021</span>
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <font size=5>Basic Ladder Rules</font>
+    </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>2.&nbsp;</span>
+    <span style=font-family:Arial>Players are reminded that FZC only accepts times set with the game cartridge,&nbsp;</span>
+    <span style=font-family:Arial>Flash cartridge ("Flashcart") with an unaltered ROM of the original game</span>
+    <span style=font-family:Arial>&nbsp;and the Wii U Virtual Console version. Flashcart users must follow the savestate rules when using a savestate or restore point.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>3. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for teams. Only submit times that are shown on your records screen.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>4. The use of cheat devices such as Action Replay are forbidden on the ladder. Restore points on the Wii U VC are not to be misused*. If it is suspected that any cheat devices have been used and/or restore points have been misused, that player will have their times removed from the ladder. <br>
+      <br> 5. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff. </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>6. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>7. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>8.&nbsp; Using Lightning Volute Two Technique (LVTT) to score multiple laps at the goal is banned.&nbsp; Players aren't allowed to submit times using LVTT to multi-lap, and any times suspected of multi-lapping will be deleted.&nbsp; This applies not just to Lightning Volute 2 but also Mute City Expansion Park 1 and 2.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>9.&nbsp; Lap Inversion (using LVTT while going backwards) to score forwards laps while going backwards is banned.&nbsp; Players aren't allowed to submit times using lap inversion to backwards-lap, and any times suspected of backwards-lapping will be deleted.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>10.&nbsp; Players are not allowed to submit times of 0 seconds on the Zero Test ladder, regardless of how 0 seconds was achieved.&nbsp; This applies not only to B2, but also to C1, C3, C7, C9, B7, A6, and S4.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>*Restore points may only be used to attempt fast laps and for infinite lives in Grand Prix mode. This means you can set a restore point <strong>before</strong>
+      <strong>entering</strong> a fast lap or you can set a restore point <strong>before</strong>
+      <strong>the timer</strong> in a five lap race <strong>starts</strong>. Misuse of restore points constitutes as using a restore point <strong>after entering</strong> a fast lap or <strong>after the timer</strong> of a five lap race <strong> starts</strong>. Even if a restore point is activated in only the first frame of the fast lap or five lap, your time will be removed, no exceptions. If a player is found abusing the restore point mechanic, their times will be subject to immediate removal from the ladder. </span>
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+    </span>
+  </p>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>
+        <span style=font-size:small>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof.</span>
+      </span> If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*. </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
+  </p>
+  <ol>
+    <li>
+      <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
+    </li>
+    <li>
+      <span style=font-family:Arial>The video must display the ending stats from the race after it is over.</span>
+    </li>
+    <li>
+      <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
+    </li>
+    <li>
+      <span style=font-family:Arial>
+        <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any too see, FZC witholds the right to take down your time associated with that video.</span>
+      </span>
+    </li>
+  </ol>
+  <p>
+    <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
+  </p>
+  <hr>
+  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
+    </span>
+  </p>
+  <p style=background-color:rgb(247,247,247)>
+    <font face=Arial>
+      <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
+    </font>
+    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
+      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+    </a>
+  </p>
+</div>
+{% endblock %}

--- a/templates/rules/gpl.html
+++ b/templates/rules/gpl.html
@@ -91,17 +91,14 @@
   <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
 </p>
 <hr>
-<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;text-align:center'>
   <span style=font-family:Arial>
     <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
   </span>
 </p>
-<p style=background-color:rgb(247,247,247)>
-  <font face=Arial>
-    <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
-  </font>
-  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
-    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-  </a>
+<p>
+  <span style=font-family:Arial>
+    <a href="/guidelines.php" target=_blank>Read here</a> - these are not enforceable rules, but guidelines for all players to follow.
+  </span>
 </p>
 {% endblock %}

--- a/templates/rules/gpl.html
+++ b/templates/rules/gpl.html
@@ -1,109 +1,107 @@
-{% extends 'base.html' %}
+{% extends 'rules/base.html' %}
 
-{% block content %}
-<div class=rules-text>
-  <p align=center>
-    <span style=font-family:Arial>
-      <span style=font-size:xx-large>
-        <strong>F-Zero Central F-ZERO GP Legend Time Submission Rules</strong>
-      </span>
+{% block rules_content %}
+<p align=center>
+  <span style=font-family:Arial>
+    <span style=font-size:xx-large>
+      <strong>F-Zero Central F-ZERO GP Legend Time Submission Rules</strong>
     </span>
-  </p>
-  <p>
-    <span style=font-family:Arial></span>
-  </p>
-  <p align=center>
-    <span style=font-family:Arial>Last Updated: 23 Mar 2021</span>
-  </p>
-  <hr>
-  <p style=text-align:center>
+  </span>
+</p>
+<p>
+  <span style=font-family:Arial></span>
+</p>
+<p align=center>
+  <span style=font-family:Arial>Last Updated: 23 Mar 2021</span>
+</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <font size=5>Basic Ladder Rules</font>
+  </span>
+</p>
+<p>
+  <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</span>
+</p>
+<p>
+  <span style=font-family:Arial>2.&nbsp;</span>
+  <span style=font-family:Arial>Players are reminded that FZC only accepts times set with the game cartridge,&nbsp;</span>
+  <span style=font-family:Arial>Flash cartridge ("Flashcart") with an unaltered ROM of the original game</span>
+  <span style=font-family:Arial>&nbsp;and the Wii U Virtual Console version. Flashcart users must follow the savestate rules when using a savestate or restore point.</span>
+</p>
+<p>
+  <span style=font-family:Arial>3. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for teams. Only submit times that are shown on your records screen.</span>
+</p>
+<p>
+  <span style=font-family:Arial>4. The use of cheat devices such as Action Replay are forbidden on the ladder. Restore points on the Wii U VC are not to be misused*. If it is suspected that any cheat devices have been used and/or restore points have been misused, that player will have their times removed from the ladder. <br>
+    <br> 5. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff. </span>
+</p>
+<p>
+  <span style=font-family:Arial>6. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
+</p>
+<p>
+  <span style=font-family:Arial>7. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
+</p>
+<p>
+  <span style=font-family:Arial>8.&nbsp; Using Lightning Volute Two Technique (LVTT) to score multiple laps at the goal is banned.&nbsp; Players aren't allowed to submit times using LVTT to multi-lap, and any times suspected of multi-lapping will be deleted.&nbsp; This applies not just to Lightning Volute 2 but also Mute City Expansion Park 1 and 2.</span>
+</p>
+<p>
+  <span style=font-family:Arial>9.&nbsp; Lap Inversion (using LVTT while going backwards) to score forwards laps while going backwards is banned.&nbsp; Players aren't allowed to submit times using lap inversion to backwards-lap, and any times suspected of backwards-lapping will be deleted.</span>
+</p>
+<p>
+  <span style=font-family:Arial>10.&nbsp; Players are not allowed to submit times of 0 seconds on the Zero Test ladder, regardless of how 0 seconds was achieved.&nbsp; This applies not only to B2, but also to C1, C3, C7, C9, B7, A6, and S4.</span>
+</p>
+<p>
+  <span style=font-family:Arial>*Restore points may only be used to attempt fast laps and for infinite lives in Grand Prix mode. This means you can set a restore point <strong>before</strong>
+    <strong>entering</strong> a fast lap or you can set a restore point <strong>before</strong>
+    <strong>the timer</strong> in a five lap race <strong>starts</strong>. Misuse of restore points constitutes as using a restore point <strong>after entering</strong> a fast lap or <strong>after the timer</strong> of a five lap race <strong> starts</strong>. Even if a restore point is activated in only the first frame of the fast lap or five lap, your time will be removed, no exceptions. If a player is found abusing the restore point mechanic, their times will be subject to immediate removal from the ladder. </span>
+</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+  </span>
+</p>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>
+      <span style=font-size:small>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof.</span>
+    </span> If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*. </span>
+</p>
+<p>
+  <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
+</p>
+<ol>
+  <li>
+    <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
+  </li>
+  <li>
+    <span style=font-family:Arial>The video must display the ending stats from the race after it is over.</span>
+  </li>
+  <li>
+    <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
+  </li>
+  <li>
     <span style=font-family:Arial>
-      <font size=5>Basic Ladder Rules</font>
+      <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any too see, FZC witholds the right to take down your time associated with that video.</span>
     </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>2.&nbsp;</span>
-    <span style=font-family:Arial>Players are reminded that FZC only accepts times set with the game cartridge,&nbsp;</span>
-    <span style=font-family:Arial>Flash cartridge ("Flashcart") with an unaltered ROM of the original game</span>
-    <span style=font-family:Arial>&nbsp;and the Wii U Virtual Console version. Flashcart users must follow the savestate rules when using a savestate or restore point.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>3. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for teams. Only submit times that are shown on your records screen.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>4. The use of cheat devices such as Action Replay are forbidden on the ladder. Restore points on the Wii U VC are not to be misused*. If it is suspected that any cheat devices have been used and/or restore points have been misused, that player will have their times removed from the ladder. <br>
-      <br> 5. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff. </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>6. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>7. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>8.&nbsp; Using Lightning Volute Two Technique (LVTT) to score multiple laps at the goal is banned.&nbsp; Players aren't allowed to submit times using LVTT to multi-lap, and any times suspected of multi-lapping will be deleted.&nbsp; This applies not just to Lightning Volute 2 but also Mute City Expansion Park 1 and 2.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>9.&nbsp; Lap Inversion (using LVTT while going backwards) to score forwards laps while going backwards is banned.&nbsp; Players aren't allowed to submit times using lap inversion to backwards-lap, and any times suspected of backwards-lapping will be deleted.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>10.&nbsp; Players are not allowed to submit times of 0 seconds on the Zero Test ladder, regardless of how 0 seconds was achieved.&nbsp; This applies not only to B2, but also to C1, C3, C7, C9, B7, A6, and S4.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>*Restore points may only be used to attempt fast laps and for infinite lives in Grand Prix mode. This means you can set a restore point <strong>before</strong>
-      <strong>entering</strong> a fast lap or you can set a restore point <strong>before</strong>
-      <strong>the timer</strong> in a five lap race <strong>starts</strong>. Misuse of restore points constitutes as using a restore point <strong>after entering</strong> a fast lap or <strong>after the timer</strong> of a five lap race <strong> starts</strong>. Even if a restore point is activated in only the first frame of the fast lap or five lap, your time will be removed, no exceptions. If a player is found abusing the restore point mechanic, their times will be subject to immediate removal from the ladder. </span>
-  </p>
-  <hr>
-  <p style=text-align:center>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
-    </span>
-  </p>
-  <p style=text-align:center>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>
-        <span style=font-size:small>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof.</span>
-      </span> If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*. </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
-  </p>
-  <ol>
-    <li>
-      <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
-    </li>
-    <li>
-      <span style=font-family:Arial>The video must display the ending stats from the race after it is over.</span>
-    </li>
-    <li>
-      <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
-    </li>
-    <li>
-      <span style=font-family:Arial>
-        <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any too see, FZC witholds the right to take down your time associated with that video.</span>
-      </span>
-    </li>
-  </ol>
-  <p>
-    <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
-  </p>
-  <hr>
-  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
-    </span>
-  </p>
-  <p style=background-color:rgb(247,247,247)>
-    <font face=Arial>
-      <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
-    </font>
-    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
-      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-    </a>
-  </p>
-</div>
+  </li>
+</ol>
+<p>
+  <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
+</p>
+<hr>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
+  </span>
+</p>
+<p style=background-color:rgb(247,247,247)>
+  <font face=Arial>
+    <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
+  </font>
+  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
+    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+  </a>
+</p>
 {% endblock %}

--- a/templates/rules/guidelines.html
+++ b/templates/rules/guidelines.html
@@ -19,149 +19,147 @@
   </span>
 </p>
 <hr>
-<pre style=word-wrap:break-word;white-space:pre-wrap>
-  <p dir=ltr style=line-height:1.38;margin-top:0pt;margin-bottom:10pt>
-    <span style=font-family:Arial>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>The purpose of these guidelines is to inform all players of good practices to ensure a productive, healthy competitive atmosphere.</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On keeping and providing proof</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>We highly suggest making sure you are able to keep and possibly provide proof of your times. It is very likely that we will ask for proof of any highly ranked time from a player who has not shown a video of a similarly highly ranked time. If a request was made, if video proof is not shown in a reasonable amount of time, we hold the right to remove the time(s) until the requested proof is shown.</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On quality and configuration of video proof</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>It would be preferred if the video and sound quality is respectable, preferably captured using a capture card if the system can easily support it. The timer and the speedometer should both be legible in the video. Show the run from start to finish, and show the time as well. If it is no longer possible to record the results with the time on the video, make sure to take a screenshot of the results and link to it on the video description.</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If you are video capturing a replay of the run for F-Zero GX, please press Z until it shows the speedometer and set the camera to one of the two main camera angles used for racing (The camera panned closest to the machine from behind, and the one panned slightly further away. NOT the first person view and camera panned out furthest away). Feel free to re-run the replay with a different camera angle on the same or on a separate video.</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>For F-Zero GX, ideally the video would be a live recording of the run, but it is not a requirement. If you don't have a live recording of the run, there is a way to display the energy level and additionally display the controller inputs and lap times with the .gci replay file in conjunction with Dolphin and Cheat Engine (Example:
-        <a href=https://youtu.be/zpqnJZO0YEI>https://youtu.be/zpqnJZO0YEI</a>).
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On video titles for a World Record run</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On the video title, mention it's a WR with [WR] or (World Record) on it to indicate that it is a current world record. If the WR gets broken by somebody else, take care to remove it or change it to [FWR] (Former World Record).</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On when to reveal that you set a WR (World Record)</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>F-Zero Central does not tolerate the hoarding of World Record times for an excessive amount of time. We do not want anyone to think they set or currently hold a WR only to find out that someone else had a faster time all along. If you set a WR, or are currently keeping it/them hidden after these guidelines have been officially been announced, regardless of how satisfied you are with it, you have a responsibility to reveal it as soon as you reasonably can. We strongly request that you reveal a new world record on the same day that it was set from now on. Taking longer than a week is unacceptable, barring exceptional circumstances.</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>There are threads on the forums for each game to post when you set a WR. The time can be revealed before verifiable proof is ready. However we do expect verifiable proof to be shown in a timely manner afterwards. </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If for whatever reason a player who revealed a WR outside of FZC (F-Zero Central), but doesn't post it on the FZC WR thread, after some time a mod will post it for the player to ensure every player is aware of the new WR.</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>Please refer to the WR submission rules of the game(s) you run on details on preparing verifiable proof.</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On how soon to submit non WR times to the ladder</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>It is recommended that you do so within three weeks of setting the PB to keep the ladder rankings up to date.</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On verifiable times that are not submitted to the ladder</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If a player has a video of a run that shows or mentions the time, but has not been submitted to the appropriate FZC ladder:</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If the time(s) has not been submitted to the ladder about 2 weeks after a site staff member discovers the run, the time will be added to the ladder if it is faster than that player's existing time or if there is no time submitted for that course. The runner will be then informed that the times have been added. We are adding it to make the ladder as accurate as possible and for competitive fairness. We take the stance that a publicly made known run is okay to be shared on the ladder. &nbsp;It will be mentioned and linked where the run was found. If there is no FZC account for the player in question, one will be created to add the time and give the player access to the account.</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If for any reason the player does not want their time(s) to be shown in the ladder, first inform us. We will request if the times can be kept on the ladder under an anonymous username. If the player declines to that request, he or she may remove the time(s) or delete their FZC account.</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>Suggestions for Submitting Times</span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>In addition to your time, adding in the 3/5 lap splits will be informative for other players. If you have a video of the run, you may link it as well, or a site staff can create a link to the video if requested. You may also include the date that you set the time</span>
+<p dir=ltr style=line-height:1.38;margin-top:0pt;margin-bottom:10pt>
+  <span style=font-family:Arial>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>The purpose of these guidelines is to inform all players of good practices to ensure a productive, healthy competitive atmosphere.</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
     </span>
-    <p dir=ltr style=line-height:1.38;margin-top:0pt;margin-bottom:10pt>
-      <span style=font-family:Arial;font-variant-numeric:normal;font-variant-east-asian:normal;background-color:transparent;font-size:11pt;font-weight:700;vertical-align:baseline>June 12, 2020 Update - Submit your best time</span>
-      <span style=font-family:Arial;font-variant-numeric:normal;font-variant-east-asian:normal;background-color:transparent;font-size:11pt;vertical-align:baseline>
-        <br class=kix-line-break>
-      </span>
-      <font face=Arial>
-        <span style=font-size:14.6667px>The act of submitting a time that is not your Personal Record for the particular category, whether it is a world record or not, is an intolerable, deceitful act that F-Zero Central condemns.</span>
-      </font>
-    </p>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On keeping and providing proof</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>We highly suggest making sure you are able to keep and possibly provide proof of your times. It is very likely that we will ask for proof of any highly ranked time from a player who has not shown a video of a similarly highly ranked time. If a request was made, if video proof is not shown in a reasonable amount of time, we hold the right to remove the time(s) until the requested proof is shown.</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On quality and configuration of video proof</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>It would be preferred if the video and sound quality is respectable, preferably captured using a capture card if the system can easily support it. The timer and the speedometer should both be legible in the video. Show the run from start to finish, and show the time as well. If it is no longer possible to record the results with the time on the video, make sure to take a screenshot of the results and link to it on the video description.</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If you are video capturing a replay of the run for F-Zero GX, please press Z until it shows the speedometer and set the camera to one of the two main camera angles used for racing (The camera panned closest to the machine from behind, and the one panned slightly further away. NOT the first person view and camera panned out furthest away). Feel free to re-run the replay with a different camera angle on the same or on a separate video.</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>For F-Zero GX, ideally the video would be a live recording of the run, but it is not a requirement. If you don't have a live recording of the run, there is a way to display the energy level and additionally display the controller inputs and lap times with the .gci replay file in conjunction with Dolphin and Cheat Engine (Example:
+      <a href=https://youtu.be/zpqnJZO0YEI>https://youtu.be/zpqnJZO0YEI</a>).
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On video titles for a World Record run</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On the video title, mention it's a WR with [WR] or (World Record) on it to indicate that it is a current world record. If the WR gets broken by somebody else, take care to remove it or change it to [FWR] (Former World Record).</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On when to reveal that you set a WR (World Record)</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>F-Zero Central does not tolerate the hoarding of World Record times for an excessive amount of time. We do not want anyone to think they set or currently hold a WR only to find out that someone else had a faster time all along. If you set a WR, or are currently keeping it/them hidden after these guidelines have been officially been announced, regardless of how satisfied you are with it, you have a responsibility to reveal it as soon as you reasonably can. We strongly request that you reveal a new world record on the same day that it was set from now on. Taking longer than a week is unacceptable, barring exceptional circumstances.</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>There are threads on the forums for each game to post when you set a WR. The time can be revealed before verifiable proof is ready. However we do expect verifiable proof to be shown in a timely manner afterwards. </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If for whatever reason a player who revealed a WR outside of FZC (F-Zero Central), but doesn't post it on the FZC WR thread, after some time a mod will post it for the player to ensure every player is aware of the new WR.</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>Please refer to the WR submission rules of the game(s) you run on details on preparing verifiable proof.</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On how soon to submit non WR times to the ladder</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>It is recommended that you do so within three weeks of setting the PB to keep the ladder rankings up to date.</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On verifiable times that are not submitted to the ladder</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If a player has a video of a run that shows or mentions the time, but has not been submitted to the appropriate FZC ladder:</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If the time(s) has not been submitted to the ladder about 2 weeks after a site staff member discovers the run, the time will be added to the ladder if it is faster than that player's existing time or if there is no time submitted for that course. The runner will be then informed that the times have been added. We are adding it to make the ladder as accurate as possible and for competitive fairness. We take the stance that a publicly made known run is okay to be shared on the ladder. &nbsp;It will be mentioned and linked where the run was found. If there is no FZC account for the player in question, one will be created to add the time and give the player access to the account.</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If for any reason the player does not want their time(s) to be shown in the ladder, first inform us. We will request if the times can be kept on the ladder under an anonymous username. If the player declines to that request, he or she may remove the time(s) or delete their FZC account.</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>Suggestions for Submitting Times</span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>In addition to your time, adding in the 3/5 lap splits will be informative for other players. If you have a video of the run, you may link it as well, or a site staff can create a link to the video if requested. You may also include the date that you set the time</span>
   </span>
-</pre>
+  <p dir=ltr style=line-height:1.38;margin-top:0pt;margin-bottom:10pt>
+    <span style=font-family:Arial;font-variant-numeric:normal;font-variant-east-asian:normal;background-color:transparent;font-size:11pt;font-weight:700;vertical-align:baseline>June 12, 2020 Update - Submit your best time</span>
+    <span style=font-family:Arial;font-variant-numeric:normal;font-variant-east-asian:normal;background-color:transparent;font-size:11pt;vertical-align:baseline>
+      <br class=kix-line-break>
+    </span>
+    <font face=Arial>
+      <span style=font-size:14.6667px>The act of submitting a time that is not your Personal Record for the particular category, whether it is a world record or not, is an intolerable, deceitful act that F-Zero Central condemns.</span>
+    </font>
+  </p>
+</span>
 <p>&nbsp;</p>
 {% endblock %}

--- a/templates/rules/guidelines.html
+++ b/templates/rules/guidelines.html
@@ -1,0 +1,167 @@
+{% extends 'rules/base.html' %}
+
+{% block rules_content %}
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <strong>
+      <span style=font-size:xx-large>
+        <span style=white-space:pre-wrap>F-Zero Central Ladder Guidelines</span>
+      </span>
+    </strong>
+  </span>
+</p>
+<p style=text-align:center>
+  <strong>
+    <span style=font-family:Arial>Introduced: July 28, 2018 / Last Updated: June 12, 2020</span>
+  </strong>
+  <span style=font-family:Arial>
+    <br type=_moz>
+  </span>
+</p>
+<hr>
+<pre style=word-wrap:break-word;white-space:pre-wrap>
+  <p dir=ltr style=line-height:1.38;margin-top:0pt;margin-bottom:10pt>
+    <span style=font-family:Arial>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>The purpose of these guidelines is to inform all players of good practices to ensure a productive, healthy competitive atmosphere.</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On keeping and providing proof</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>We highly suggest making sure you are able to keep and possibly provide proof of your times. It is very likely that we will ask for proof of any highly ranked time from a player who has not shown a video of a similarly highly ranked time. If a request was made, if video proof is not shown in a reasonable amount of time, we hold the right to remove the time(s) until the requested proof is shown.</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On quality and configuration of video proof</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>It would be preferred if the video and sound quality is respectable, preferably captured using a capture card if the system can easily support it. The timer and the speedometer should both be legible in the video. Show the run from start to finish, and show the time as well. If it is no longer possible to record the results with the time on the video, make sure to take a screenshot of the results and link to it on the video description.</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If you are video capturing a replay of the run for F-Zero GX, please press Z until it shows the speedometer and set the camera to one of the two main camera angles used for racing (The camera panned closest to the machine from behind, and the one panned slightly further away. NOT the first person view and camera panned out furthest away). Feel free to re-run the replay with a different camera angle on the same or on a separate video.</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>For F-Zero GX, ideally the video would be a live recording of the run, but it is not a requirement. If you don't have a live recording of the run, there is a way to display the energy level and additionally display the controller inputs and lap times with the .gci replay file in conjunction with Dolphin and Cheat Engine (Example:
+        <a href=https://youtu.be/zpqnJZO0YEI>https://youtu.be/zpqnJZO0YEI</a>).
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On video titles for a World Record run</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On the video title, mention it's a WR with [WR] or (World Record) on it to indicate that it is a current world record. If the WR gets broken by somebody else, take care to remove it or change it to [FWR] (Former World Record).</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On when to reveal that you set a WR (World Record)</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>F-Zero Central does not tolerate the hoarding of World Record times for an excessive amount of time. We do not want anyone to think they set or currently hold a WR only to find out that someone else had a faster time all along. If you set a WR, or are currently keeping it/them hidden after these guidelines have been officially been announced, regardless of how satisfied you are with it, you have a responsibility to reveal it as soon as you reasonably can. We strongly request that you reveal a new world record on the same day that it was set from now on. Taking longer than a week is unacceptable, barring exceptional circumstances.</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>There are threads on the forums for each game to post when you set a WR. The time can be revealed before verifiable proof is ready. However we do expect verifiable proof to be shown in a timely manner afterwards. </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If for whatever reason a player who revealed a WR outside of FZC (F-Zero Central), but doesn't post it on the FZC WR thread, after some time a mod will post it for the player to ensure every player is aware of the new WR.</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>Please refer to the WR submission rules of the game(s) you run on details on preparing verifiable proof.</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On how soon to submit non WR times to the ladder</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>It is recommended that you do so within three weeks of setting the PB to keep the ladder rankings up to date.</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>On verifiable times that are not submitted to the ladder</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If a player has a video of a run that shows or mentions the time, but has not been submitted to the appropriate FZC ladder:</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If the time(s) has not been submitted to the ladder about 2 weeks after a site staff member discovers the run, the time will be added to the ladder if it is faster than that player's existing time or if there is no time submitted for that course. The runner will be then informed that the times have been added. We are adding it to make the ladder as accurate as possible and for competitive fairness. We take the stance that a publicly made known run is okay to be shared on the ladder. &nbsp;It will be mentioned and linked where the run was found. If there is no FZC account for the player in question, one will be created to add the time and give the player access to the account.</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>If for any reason the player does not want their time(s) to be shown in the ladder, first inform us. We will request if the times can be kept on the ladder under an anonymous username. If the player declines to that request, he or she may remove the time(s) or delete their FZC account.</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-weight:700;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>Suggestions for Submitting Times</span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <span style=font-size:11pt;background-color:transparent;font-variant-numeric:normal;font-variant-east-asian:normal;vertical-align:baseline>In addition to your time, adding in the 3/5 lap splits will be informative for other players. If you have a video of the run, you may link it as well, or a site staff can create a link to the video if requested. You may also include the date that you set the time</span>
+    </span>
+    <p dir=ltr style=line-height:1.38;margin-top:0pt;margin-bottom:10pt>
+      <span style=font-family:Arial;font-variant-numeric:normal;font-variant-east-asian:normal;background-color:transparent;font-size:11pt;font-weight:700;vertical-align:baseline>June 12, 2020 Update - Submit your best time</span>
+      <span style=font-family:Arial;font-variant-numeric:normal;font-variant-east-asian:normal;background-color:transparent;font-size:11pt;vertical-align:baseline>
+        <br class=kix-line-break>
+      </span>
+      <font face=Arial>
+        <span style=font-size:14.6667px>The act of submitting a time that is not your Personal Record for the particular category, whether it is a world record or not, is an intolerable, deceitful act that F-Zero Central condemns.</span>
+      </font>
+    </p>
+  </span>
+</pre>
+<p>&nbsp;</p>
+{% endblock %}

--- a/templates/rules/gx.html
+++ b/templates/rules/gx.html
@@ -225,19 +225,17 @@
   <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013, does not need to adhere by the requirements of "Full Video Proof".</span>
 </p>
 <hr>
-<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;text-align:center'>
   <span style=font-family:Arial>
     <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
   </span>
 </p>
-<p style=background-color:rgb(247,247,247)>
-  <font face=Arial>
-    <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
-  </font>
-  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
-    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-  </a>
+<p>
+  <span style=font-family:Arial>
+    <a href="/guidelines.php" target=_blank>Read here</a> - these are not enforceable rules, but guidelines for all players to follow.
+  </span>
 </p>
+<hr>
 <p>
   <strong>-UPDATE- 15th September 2014:</strong>
 </p>

--- a/templates/rules/gx.html
+++ b/templates/rules/gx.html
@@ -1,305 +1,303 @@
-{% extends 'base.html' %}
+{% extends 'rules/base.html' %}
 
-{% block content %}
-<div class=rules-text>
-  <p style=text-align:center>
-    <span style=font-size:xx-large>
-      <strong>
-        <span style=font-family:Arial>F-ZERO Central F-ZERO GX Time Submission Rules</span>
-      </strong>
-    </span>
-  </p>
-  <p>
-    <span style=font-family:Arial></span>
-  </p>
-  <p align=center>
-    <u>
-      <strong>
-        <span style=font-family:Arial>Last Updated:</span>
-      </strong>
-    </u>
+{% block rules_content %}
+<p style=text-align:center>
+  <span style=font-size:xx-large>
     <strong>
-      <span style=font-family:Arial>&nbsp;23rd March 2021</span>
+      <span style=font-family:Arial>F-ZERO Central F-ZERO GX Time Submission Rules</span>
     </strong>
-  </p>
-  <hr>
-  <p align=center>
-    <span style=font-family:Arial>&nbsp;</span>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>Rules for All Three Ladders</span>
+  </span>
+</p>
+<p>
+  <span style=font-family:Arial></span>
+</p>
+<p align=center>
+  <u>
+    <strong>
+      <span style=font-family:Arial>Last Updated:</span>
+    </strong>
+  </u>
+  <strong>
+    <span style=font-family:Arial>&nbsp;23rd March 2021</span>
+  </strong>
+</p>
+<hr>
+<p align=center>
+  <span style=font-family:Arial>&nbsp;</span>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>Rules for All Three Ladders</span>
+  </span>
+</p>
+<p>
+  <span style=font-family:Arial></span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>1. </span>
+  <span style=font-family:Arial>Course Times and Speeds must be obtained using Time Attack mode. Lap Times must be obtained with either Time Attack mode or Practice mode with CPUs off. </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>2. If you have the Restore feature turned on in practice mode to set a fast lap, the following exploits cannot be used: </span>
+</p>
+<ul>
+  <li>
+    <span style=font-family:Arial>Going out of bounds before completing a lap, but still complete the lap as the machine is being restored - <a href="http://www.youtube.com/watch?v=jTdh8jtV9vQ">Video Demonstration</a>
     </span>
-  </p>
-  <p>
-    <span style=font-family:Arial></span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>1. </span>
-    <span style=font-family:Arial>Course Times and Speeds must be obtained using Time Attack mode. Lap Times must be obtained with either Time Attack mode or Practice mode with CPUs off. </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>2. If you have the Restore feature turned on in practice mode to set a fast lap, the following exploits cannot be used: </span>
-  </p>
-  <ul>
-    <li>
-      <span style=font-family:Arial>Going out of bounds before completing a lap, but still complete the lap as the machine is being restored - <a href="http://www.youtube.com/watch?v=jTdh8jtV9vQ">Video Demonstration</a>
-      </span>
-    </li>
-    <li>
-      <span style=font-family:Arial>Falling off course immediately after the lap begins in a specific way that makes the machine be restored right before the start/finish line, completing the lap in potentially under 4 seconds - <a href="http://www.youtube.com/watch?v=4DO1HFK9j_c">Video Demonstration</a>
-      </span>
-      <span style=font-size:small>&nbsp;</span>
-    </li>
-  </ul>
-  <p style=text-align:left>
-    <span style=font-family:Arial>3. Turbo Controllers are banned from being used on any of the three F-ZERO GX Ladders, as they present the player with an unfair advantage. <strong>Players are reminded that if they have any times set with a turbo controller, they must change them immediately.</strong>
+  </li>
+  <li>
+    <span style=font-family:Arial>Falling off course immediately after the lap begins in a specific way that makes the machine be restored right before the start/finish line, completing the lap in potentially under 4 seconds - <a href="http://www.youtube.com/watch?v=4DO1HFK9j_c">Video Demonstration</a>
     </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>4. Players should add in their comments if they played in 50Hz. Times set in 50Hz are not accepted as a "world record", since any version of the game supports 60Hz.</span>
-    <span style=font-family:Arial>
-      <br>
-    </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>5. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition; it's not meant for teams. <br>
-    </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>6. The use of cheat devices such as Action Replay are forbidden on all of the ladders. If it is suspected that a cheat device has been used, then that player will have their times removed from the ladder.&nbsp; <br>
-    </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>*NOTE: An exception has been made to F-ZERO GX, as Action&nbsp;Replay is the only method available to unlock the Japanese AX event parts. Players should use the AR only once to unlock them. <br>
-    </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>7. FZC reserves the right to request proof of your times. Proof could be requested at random, or if there's a concern that false times might have been submitted. Any requests for proof will be handled by a member of the F-ZERO Staff. <br>
-    </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>8. Multiple accounts for the same player are not allowed, neither are joint accounts. <br>
-    </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>9. Emulators (such as Dolphin) are not allowed.</span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>10. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders. Cheaters will also be considered for immediate removal from other F-ZERO Ladders on FZC.</span>
-  </p>
-  <p style=text-align:left>&nbsp;</p>
-  <div>
-    <strong>Additional Rules for USB/SD Loaders</strong>
-  </div>
-  <div>&nbsp;</div>
-  <div>Due to the nature of how USB/SD loaders work, a few extra rules are needed to ensure no players obtain unexpected advantages over Disc users.</div>
-  <div>&nbsp;</div>
-  <div>Methods of USB/SD Loading allowed:</div>
-  <div>1. HDD or USB stick plugged to the back of a Wii</div>
-  <div>2. SD Card inserted in the front slot of a Wii</div>
-  <div>3. SDML adapter on Memory Card slot on GameCube</div>
-  <div>4. GCLoader Drive Replacement installed on GameCube</div>
-  <div>5. SD Card inserted in the front slot of a Wii U</div>
-  <div>6. HDD or USB stick plugged to a USB port on a Wii U</div>
-  <div>&nbsp;</div>
-  <div>Only these methods have been verified by the Staff and enough testing has been conducted to ensure times set using them are identical to times set with a Disc.</div>
-  <div>&nbsp;</div>
-  <div>Rules regarding usage of the game:</div>
-  <div>&nbsp;</div>
-  <div>1. The F-Zero GX image file (ISO) must not be modified in any way. it must be the same image file obtained by reading a F-Zero GX game disc with software capable of creating a backup image of the game. this prevents any possible advantage provided by creating new visual or audio cues.</div>
-  <div>2. Additional proof for times will be required in the form of Replay files. through testing, it's been determined that Replay files will only sync with game versions that don't have any modifications to machine stats.&nbsp;this ensures players won't be editing the game's files. as a side effect, Story Mode times set on USB/SD Loaders won't be allowed because this form of proof can't be obtained from that mode.</div>
-  <div>3. USB/SD Loader software such as Nintendont usually comes with functionality for cheat codes. make sure they are turned off when setting times. you're allowed to unlock the Event Parts (Gold Parts) in the same way it is done with Action Replay.</div>
-  <p style=text-align:left>&nbsp;</p>
-  <hr>
-  <p style=text-align:center>
-    <span style=font-family:Arial>&nbsp;</span>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>Max Speed Ladder</span>
-    </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>1. Times in the GX Max Speed Ladder must be set at 100% Max Speed settings <strong>ONLY.</strong>
-      <br>
-    </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>2. No checkpoint skipping is allowed to be used in the Max Speed ladder. This includes the use of this shortcut on PRSLS: </span>
-    <font face=Verdana>
-      <a href=http://wrvids.com/F-Zero_series/F-Zero%20GX/prsls_midiman_nazo.mpg>
-        <span style=font-family:Arial>prsls_mts_shortcut.mpg</span>
-      </a>
-    </font>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>3. Quickturn alternations with custom machines with a body of E/D are banned, unless if it is naturally required by the track, either by a curve, or to align a certain position and angle. This rule has been done to prevent snaking with custom vehicles.</span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>4. Side Attacks are allowed to be used, but HSSA (Hyper Speed Side Attack) is not allowed.</span>
-  </p>
-  <p style=text-align:left>-</p>
-  <p>
-    <strong>(Not ladder rules!)</strong>&nbsp;- Below are the rules applied to the Non-Side Attack category displayed in the&nbsp; <a href="http://www.fzerocentral.org/viewtopic.php?t=13710">WR List</a>:
-  </p>
-  <ol>
-    <li>100% Max Speed settings ONLY.</li>
-    <li>No checkpoint skipping is allowed to be used in the Non-SA category. This includes the use of this shortcut on PRSLS: <font face=Verdana>
-        <a href=http://wrvids.com/F-Zero_series/F-Zero%20GX/prsls_midiman_nazo.mpg>
-          <span style=font-family:Arial>prsls_mts_shortcut.mpg</span>
-        </a>
-      </font>
-    </li>
-    <li>Side Attacks are not allowed.</li>
-    <li>Machines with a body rating of E or D are not allowed.</li>
-  </ol>
-  <hr>
-  <p style=text-align:center>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>Snaking Ladder</span>
-    </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>1. Times in the GX Snaking Ladder must be set at 0% (Max Acceleration) settings <strong>ONLY.</strong>
-    </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>2. No checkpoint skipping is allowed to be used in the Snaking ladder. This includes the use of this shortcut on PRSLS:&nbsp;</span>
-    <font face=Verdana>
-      <a href=http://wrvids.com/F-Zero_series/F-Zero%20GX/prsls_midiman_nazo.mpg>
-        <span style=font-family:Arial>prsls_mts_shortcut.mpg</span>
-      </a>
-    </font>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>3. Snaking patterns in the air are only allowed to be performed <strong>ONCE</strong>&nbsp;when using a machine that weighs less than 2050kg. This has been done to prevent unintentional flying. </span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>4. Flying through the whole course, even without skipping checkpoints, is prohibited.</span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>5. Side Attacks are allowed to be used, but HSSA (Hyper Speed Side Attack) is not allowed.</span>
-  </p>
-  <hr>
-  <p style=text-align:center>&nbsp; <span style=font-family:Arial></span>
-    <span style=font-size:x-large>Open Ladder</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>1. Times in the GX Open Ladder can be set at any setting. This ladder allows the use of Snaking, Space Flying, and Non-Snaking. </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>2.&nbsp;Checkpoint skipping is also allowed in this ladder.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial></span>
-  </p>
-  <p>
-    <span style=font-family:Arial>3. HSSA (Hyper Speed Side Attack) is allowed in this ladder.</span>
-  </p>
-  <hr>
-  <p style=text-align:center>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
-    </span>
-  </p>
-  <p style=text-align:center>
-    <span style=font-family:Arial>In order to have an FZC Best or World Record to be accepted to FZC, one must follow the requirements of "full video proof". If an FZC Best/WR does not adhere to the requirements listed for "full video proof", the time is subject to immediate removal from the ladder.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>Requirements of "Full Video Proof":</span>
-  </p>
-  <ol>
-    <li>
-      <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
-    </li>
-    <li>
-      <span style=font-family:Arial>The video <u>should</u> display the ending stats from the race after it is ove <span style=color:rgb(0,0,0)>r.</span>
-      </span>
-    </li>
-    <li>
-      <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
-    </li>
-    <li>
-      <span style=font-family:Arial>
-        <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video from public, FZC witholds the right to take down your time associated with that video.</span>
-      </span>
-    </li>
-  </ol>
-  <p>
-    <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013, does not need to adhere by the requirements of "Full Video Proof".</span>
-  </p>
-  <hr>
-  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
-    </span>
-  </p>
-  <p style=background-color:rgb(247,247,247)>
-    <font face=Arial>
-      <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
-    </font>
-    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
-      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-    </a>
-  </p>
-  <p>
-    <strong>-UPDATE- 15th September 2014:</strong>
-  </p>
-  <p>As of the 15th of September 2014, the replay mode cannot be used as a proof for FZC Bests/World Records anymore. (Explanation given on this page: <a href="http://www.fzerocentral.org/viewtopic.php?t=13926&amp;start=0">http://www.fzerocentral.org/viewtopic.php?t=13926&amp;start=0</a>) </p>
-  <p>The updated rules requires the WR player to do one of the following options:</p>
-  <ol>
-    <li>Make a live recording. Video example: <a href="https://www.youtube.com/watch?v=FDrXT_nRS_E">https://www.youtube.com/watch?v=FDrXT_nRS_E</a>
-    </li>
-    <li>Make a recording that starts from the results screen (with the lap splits and such), and ends after the "instant replay mode" (replay mode with the replay icon shown at the bottom left of the screen). Video Example: <a href="https://www.youtube.com/watch?v=E5sRMcSmLGs">https://www.youtube.com/watch?v=E5sRMcSmLGs</a>
-    </li>
-  </ol>
-  <p>If for whatever reason, suspicion were to occur from the above method of providing proof, further proof (such as streaming) could get requested.</p>
-  <p>*NOTE: FZC Bests/World Records that used the replay mode as a proof before the 15th of September 2014 are still valid as FZC Bests/World Records.</p>
-  <p>&nbsp;</p>
-  <p>
-    <strong>-UPDATE- 15th August 2015:</strong>
-  </p>
-  <p>As of the 15th of August 2015, the Max Speed rules have been amended to clarify the use of quick turns in straight roads to prevent deliberate Snaking in 100% Max Speed settings and to make things more clear overall.</p>
-  <p>&nbsp;</p>
-  <p>
-    <strong>-UPDATE- 5th September 2017:</strong>
-  </p>
-  <p>Added a rule for all three ladders to clarify which game modes can be used: "Course Times and Speeds must be obtained using Time Attack mode. Lap Times must be obtained with either Time Attack mode or Practice mode with CPUs off."</p>
-  <p>Removed "Only submit times that are shown on your records screen." sentence from the "individual competition" rule. Having times saved to your memory card is not a requirement since (1) Spaceflying times below 20 seconds may not save due to a glitch, and (2) Lap Times achieved in Practice mode don't get saved.</p>
-  <p>&nbsp;</p>
-  <p>
-    <strong>-UPDATE- 17th June 2018:</strong>
-  </p>
-  <p>As of the 17th of June 2018, USB Loaders are allowed to use for setting Course Times and Fast Laps.</p>
-  <p>old rules that prohibited the use of ISOs were removed.</p>
-  <p>&nbsp;</p>
-  <p>
-    <strong>-UPDATE- 17th January 2021:</strong>
-  </p>
-  <p>
-    <span style=font-family:Arial>Banned two exploits that take advantage of the Restore feature in Practice Mode that allows to set fast lap times that would not be possible to do in Time Attack mode:</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>"If you have the Restore feature turned on in practice mode to set a fast lap, the following exploits cannot be used</span>
-  </p>
-  <ul>
-    <li>
-      <span style=font-family:Arial>Going out of bounds before completing a lap, but still complete the lap as the machine is being restored -&nbsp;</span>
-      <a href="https://www.youtube.com/watch?v=jTdh8jtV9vQ">
-        <span style=font-family:Arial>Video Demonstration</span>
-      </a>
-    </li>
-    <li>
-      <span style=font-family:Arial>Falling off course immediately after the lap begins in a specific way that makes the machine be restored right before the start/finish line, completing the lap in potentially under 4 seconds -&nbsp;</span>
-      <a href="https://www.youtube.com/watch?v=4DO1HFK9j_c">
-        <span style=font-family:Arial>Video Demonstration</span>
-      </a>
-      <span style=font-family:Arial>"</span>
-    </li>
-  </ul>
-  <p>&nbsp;</p>
-  <p>
-    <strong>-UPDATE- 23rd March 2021:</strong>
-  </p>
-  <p>added GCLoader to the allowed USB/SD Loader methods</p>
-  <p>changed "USB Loader" to "USB/SD Loader" for better acurracy</p>
-  <p>&nbsp;</p>
+    <span style=font-size:small>&nbsp;</span>
+  </li>
+</ul>
+<p style=text-align:left>
+  <span style=font-family:Arial>3. Turbo Controllers are banned from being used on any of the three F-ZERO GX Ladders, as they present the player with an unfair advantage. <strong>Players are reminded that if they have any times set with a turbo controller, they must change them immediately.</strong>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>4. Players should add in their comments if they played in 50Hz. Times set in 50Hz are not accepted as a "world record", since any version of the game supports 60Hz.</span>
+  <span style=font-family:Arial>
+    <br>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>5. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition; it's not meant for teams. <br>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>6. The use of cheat devices such as Action Replay are forbidden on all of the ladders. If it is suspected that a cheat device has been used, then that player will have their times removed from the ladder.&nbsp; <br>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>*NOTE: An exception has been made to F-ZERO GX, as Action&nbsp;Replay is the only method available to unlock the Japanese AX event parts. Players should use the AR only once to unlock them. <br>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>7. FZC reserves the right to request proof of your times. Proof could be requested at random, or if there's a concern that false times might have been submitted. Any requests for proof will be handled by a member of the F-ZERO Staff. <br>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>8. Multiple accounts for the same player are not allowed, neither are joint accounts. <br>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>9. Emulators (such as Dolphin) are not allowed.</span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>10. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders. Cheaters will also be considered for immediate removal from other F-ZERO Ladders on FZC.</span>
+</p>
+<p style=text-align:left>&nbsp;</p>
+<div>
+  <strong>Additional Rules for USB/SD Loaders</strong>
 </div>
+<div>&nbsp;</div>
+<div>Due to the nature of how USB/SD loaders work, a few extra rules are needed to ensure no players obtain unexpected advantages over Disc users.</div>
+<div>&nbsp;</div>
+<div>Methods of USB/SD Loading allowed:</div>
+<div>1. HDD or USB stick plugged to the back of a Wii</div>
+<div>2. SD Card inserted in the front slot of a Wii</div>
+<div>3. SDML adapter on Memory Card slot on GameCube</div>
+<div>4. GCLoader Drive Replacement installed on GameCube</div>
+<div>5. SD Card inserted in the front slot of a Wii U</div>
+<div>6. HDD or USB stick plugged to a USB port on a Wii U</div>
+<div>&nbsp;</div>
+<div>Only these methods have been verified by the Staff and enough testing has been conducted to ensure times set using them are identical to times set with a Disc.</div>
+<div>&nbsp;</div>
+<div>Rules regarding usage of the game:</div>
+<div>&nbsp;</div>
+<div>1. The F-Zero GX image file (ISO) must not be modified in any way. it must be the same image file obtained by reading a F-Zero GX game disc with software capable of creating a backup image of the game. this prevents any possible advantage provided by creating new visual or audio cues.</div>
+<div>2. Additional proof for times will be required in the form of Replay files. through testing, it's been determined that Replay files will only sync with game versions that don't have any modifications to machine stats.&nbsp;this ensures players won't be editing the game's files. as a side effect, Story Mode times set on USB/SD Loaders won't be allowed because this form of proof can't be obtained from that mode.</div>
+<div>3. USB/SD Loader software such as Nintendont usually comes with functionality for cheat codes. make sure they are turned off when setting times. you're allowed to unlock the Event Parts (Gold Parts) in the same way it is done with Action Replay.</div>
+<p style=text-align:left>&nbsp;</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>&nbsp;</span>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>Max Speed Ladder</span>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>1. Times in the GX Max Speed Ladder must be set at 100% Max Speed settings <strong>ONLY.</strong>
+    <br>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>2. No checkpoint skipping is allowed to be used in the Max Speed ladder. This includes the use of this shortcut on PRSLS: </span>
+  <font face=Verdana>
+    <a href=http://wrvids.com/F-Zero_series/F-Zero%20GX/prsls_midiman_nazo.mpg>
+      <span style=font-family:Arial>prsls_mts_shortcut.mpg</span>
+    </a>
+  </font>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>3. Quickturn alternations with custom machines with a body of E/D are banned, unless if it is naturally required by the track, either by a curve, or to align a certain position and angle. This rule has been done to prevent snaking with custom vehicles.</span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>4. Side Attacks are allowed to be used, but HSSA (Hyper Speed Side Attack) is not allowed.</span>
+</p>
+<p style=text-align:left>-</p>
+<p>
+  <strong>(Not ladder rules!)</strong>&nbsp;- Below are the rules applied to the Non-Side Attack category displayed in the&nbsp; <a href="http://www.fzerocentral.org/viewtopic.php?t=13710">WR List</a>:
+</p>
+<ol>
+  <li>100% Max Speed settings ONLY.</li>
+  <li>No checkpoint skipping is allowed to be used in the Non-SA category. This includes the use of this shortcut on PRSLS: <font face=Verdana>
+      <a href=http://wrvids.com/F-Zero_series/F-Zero%20GX/prsls_midiman_nazo.mpg>
+        <span style=font-family:Arial>prsls_mts_shortcut.mpg</span>
+      </a>
+    </font>
+  </li>
+  <li>Side Attacks are not allowed.</li>
+  <li>Machines with a body rating of E or D are not allowed.</li>
+</ol>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>Snaking Ladder</span>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>1. Times in the GX Snaking Ladder must be set at 0% (Max Acceleration) settings <strong>ONLY.</strong>
+  </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>2. No checkpoint skipping is allowed to be used in the Snaking ladder. This includes the use of this shortcut on PRSLS:&nbsp;</span>
+  <font face=Verdana>
+    <a href=http://wrvids.com/F-Zero_series/F-Zero%20GX/prsls_midiman_nazo.mpg>
+      <span style=font-family:Arial>prsls_mts_shortcut.mpg</span>
+    </a>
+  </font>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>3. Snaking patterns in the air are only allowed to be performed <strong>ONCE</strong>&nbsp;when using a machine that weighs less than 2050kg. This has been done to prevent unintentional flying. </span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>4. Flying through the whole course, even without skipping checkpoints, is prohibited.</span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>5. Side Attacks are allowed to be used, but HSSA (Hyper Speed Side Attack) is not allowed.</span>
+</p>
+<hr>
+<p style=text-align:center>&nbsp; <span style=font-family:Arial></span>
+  <span style=font-size:x-large>Open Ladder</span>
+</p>
+<p>
+  <span style=font-family:Arial>1. Times in the GX Open Ladder can be set at any setting. This ladder allows the use of Snaking, Space Flying, and Non-Snaking. </span>
+</p>
+<p>
+  <span style=font-family:Arial>2.&nbsp;Checkpoint skipping is also allowed in this ladder.</span>
+</p>
+<p>
+  <span style=font-family:Arial></span>
+</p>
+<p>
+  <span style=font-family:Arial>3. HSSA (Hyper Speed Side Attack) is allowed in this ladder.</span>
+</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+  </span>
+</p>
+<p style=text-align:center>
+  <span style=font-family:Arial>In order to have an FZC Best or World Record to be accepted to FZC, one must follow the requirements of "full video proof". If an FZC Best/WR does not adhere to the requirements listed for "full video proof", the time is subject to immediate removal from the ladder.</span>
+</p>
+<p>
+  <span style=font-family:Arial>Requirements of "Full Video Proof":</span>
+</p>
+<ol>
+  <li>
+    <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
+  </li>
+  <li>
+    <span style=font-family:Arial>The video <u>should</u> display the ending stats from the race after it is ove <span style=color:rgb(0,0,0)>r.</span>
+    </span>
+  </li>
+  <li>
+    <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
+  </li>
+  <li>
+    <span style=font-family:Arial>
+      <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video from public, FZC witholds the right to take down your time associated with that video.</span>
+    </span>
+  </li>
+</ol>
+<p>
+  <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013, does not need to adhere by the requirements of "Full Video Proof".</span>
+</p>
+<hr>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
+  </span>
+</p>
+<p style=background-color:rgb(247,247,247)>
+  <font face=Arial>
+    <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
+  </font>
+  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
+    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+  </a>
+</p>
+<p>
+  <strong>-UPDATE- 15th September 2014:</strong>
+</p>
+<p>As of the 15th of September 2014, the replay mode cannot be used as a proof for FZC Bests/World Records anymore. (Explanation given on this page: <a href="http://www.fzerocentral.org/viewtopic.php?t=13926&amp;start=0">http://www.fzerocentral.org/viewtopic.php?t=13926&amp;start=0</a>) </p>
+<p>The updated rules requires the WR player to do one of the following options:</p>
+<ol>
+  <li>Make a live recording. Video example: <a href="https://www.youtube.com/watch?v=FDrXT_nRS_E">https://www.youtube.com/watch?v=FDrXT_nRS_E</a>
+  </li>
+  <li>Make a recording that starts from the results screen (with the lap splits and such), and ends after the "instant replay mode" (replay mode with the replay icon shown at the bottom left of the screen). Video Example: <a href="https://www.youtube.com/watch?v=E5sRMcSmLGs">https://www.youtube.com/watch?v=E5sRMcSmLGs</a>
+  </li>
+</ol>
+<p>If for whatever reason, suspicion were to occur from the above method of providing proof, further proof (such as streaming) could get requested.</p>
+<p>*NOTE: FZC Bests/World Records that used the replay mode as a proof before the 15th of September 2014 are still valid as FZC Bests/World Records.</p>
+<p>&nbsp;</p>
+<p>
+  <strong>-UPDATE- 15th August 2015:</strong>
+</p>
+<p>As of the 15th of August 2015, the Max Speed rules have been amended to clarify the use of quick turns in straight roads to prevent deliberate Snaking in 100% Max Speed settings and to make things more clear overall.</p>
+<p>&nbsp;</p>
+<p>
+  <strong>-UPDATE- 5th September 2017:</strong>
+</p>
+<p>Added a rule for all three ladders to clarify which game modes can be used: "Course Times and Speeds must be obtained using Time Attack mode. Lap Times must be obtained with either Time Attack mode or Practice mode with CPUs off."</p>
+<p>Removed "Only submit times that are shown on your records screen." sentence from the "individual competition" rule. Having times saved to your memory card is not a requirement since (1) Spaceflying times below 20 seconds may not save due to a glitch, and (2) Lap Times achieved in Practice mode don't get saved.</p>
+<p>&nbsp;</p>
+<p>
+  <strong>-UPDATE- 17th June 2018:</strong>
+</p>
+<p>As of the 17th of June 2018, USB Loaders are allowed to use for setting Course Times and Fast Laps.</p>
+<p>old rules that prohibited the use of ISOs were removed.</p>
+<p>&nbsp;</p>
+<p>
+  <strong>-UPDATE- 17th January 2021:</strong>
+</p>
+<p>
+  <span style=font-family:Arial>Banned two exploits that take advantage of the Restore feature in Practice Mode that allows to set fast lap times that would not be possible to do in Time Attack mode:</span>
+</p>
+<p>
+  <span style=font-family:Arial>"If you have the Restore feature turned on in practice mode to set a fast lap, the following exploits cannot be used</span>
+</p>
+<ul>
+  <li>
+    <span style=font-family:Arial>Going out of bounds before completing a lap, but still complete the lap as the machine is being restored -&nbsp;</span>
+    <a href="https://www.youtube.com/watch?v=jTdh8jtV9vQ">
+      <span style=font-family:Arial>Video Demonstration</span>
+    </a>
+  </li>
+  <li>
+    <span style=font-family:Arial>Falling off course immediately after the lap begins in a specific way that makes the machine be restored right before the start/finish line, completing the lap in potentially under 4 seconds -&nbsp;</span>
+    <a href="https://www.youtube.com/watch?v=4DO1HFK9j_c">
+      <span style=font-family:Arial>Video Demonstration</span>
+    </a>
+    <span style=font-family:Arial>"</span>
+  </li>
+</ul>
+<p>&nbsp;</p>
+<p>
+  <strong>-UPDATE- 23rd March 2021:</strong>
+</p>
+<p>added GCLoader to the allowed USB/SD Loader methods</p>
+<p>changed "USB Loader" to "USB/SD Loader" for better acurracy</p>
+<p>&nbsp;</p>
 {% endblock %}

--- a/templates/rules/gx.html
+++ b/templates/rules/gx.html
@@ -1,0 +1,305 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class=rules-text>
+  <p style=text-align:center>
+    <span style=font-size:xx-large>
+      <strong>
+        <span style=font-family:Arial>F-ZERO Central F-ZERO GX Time Submission Rules</span>
+      </strong>
+    </span>
+  </p>
+  <p>
+    <span style=font-family:Arial></span>
+  </p>
+  <p align=center>
+    <u>
+      <strong>
+        <span style=font-family:Arial>Last Updated:</span>
+      </strong>
+    </u>
+    <strong>
+      <span style=font-family:Arial>&nbsp;23rd March 2021</span>
+    </strong>
+  </p>
+  <hr>
+  <p align=center>
+    <span style=font-family:Arial>&nbsp;</span>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>Rules for All Three Ladders</span>
+    </span>
+  </p>
+  <p>
+    <span style=font-family:Arial></span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>1. </span>
+    <span style=font-family:Arial>Course Times and Speeds must be obtained using Time Attack mode. Lap Times must be obtained with either Time Attack mode or Practice mode with CPUs off. </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>2. If you have the Restore feature turned on in practice mode to set a fast lap, the following exploits cannot be used: </span>
+  </p>
+  <ul>
+    <li>
+      <span style=font-family:Arial>Going out of bounds before completing a lap, but still complete the lap as the machine is being restored - <a href="http://www.youtube.com/watch?v=jTdh8jtV9vQ">Video Demonstration</a>
+      </span>
+    </li>
+    <li>
+      <span style=font-family:Arial>Falling off course immediately after the lap begins in a specific way that makes the machine be restored right before the start/finish line, completing the lap in potentially under 4 seconds - <a href="http://www.youtube.com/watch?v=4DO1HFK9j_c">Video Demonstration</a>
+      </span>
+      <span style=font-size:small>&nbsp;</span>
+    </li>
+  </ul>
+  <p style=text-align:left>
+    <span style=font-family:Arial>3. Turbo Controllers are banned from being used on any of the three F-ZERO GX Ladders, as they present the player with an unfair advantage. <strong>Players are reminded that if they have any times set with a turbo controller, they must change them immediately.</strong>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>4. Players should add in their comments if they played in 50Hz. Times set in 50Hz are not accepted as a "world record", since any version of the game supports 60Hz.</span>
+    <span style=font-family:Arial>
+      <br>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>5. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition; it's not meant for teams. <br>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>6. The use of cheat devices such as Action Replay are forbidden on all of the ladders. If it is suspected that a cheat device has been used, then that player will have their times removed from the ladder.&nbsp; <br>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>*NOTE: An exception has been made to F-ZERO GX, as Action&nbsp;Replay is the only method available to unlock the Japanese AX event parts. Players should use the AR only once to unlock them. <br>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>7. FZC reserves the right to request proof of your times. Proof could be requested at random, or if there's a concern that false times might have been submitted. Any requests for proof will be handled by a member of the F-ZERO Staff. <br>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>8. Multiple accounts for the same player are not allowed, neither are joint accounts. <br>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>9. Emulators (such as Dolphin) are not allowed.</span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>10. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders. Cheaters will also be considered for immediate removal from other F-ZERO Ladders on FZC.</span>
+  </p>
+  <p style=text-align:left>&nbsp;</p>
+  <div>
+    <strong>Additional Rules for USB/SD Loaders</strong>
+  </div>
+  <div>&nbsp;</div>
+  <div>Due to the nature of how USB/SD loaders work, a few extra rules are needed to ensure no players obtain unexpected advantages over Disc users.</div>
+  <div>&nbsp;</div>
+  <div>Methods of USB/SD Loading allowed:</div>
+  <div>1. HDD or USB stick plugged to the back of a Wii</div>
+  <div>2. SD Card inserted in the front slot of a Wii</div>
+  <div>3. SDML adapter on Memory Card slot on GameCube</div>
+  <div>4. GCLoader Drive Replacement installed on GameCube</div>
+  <div>5. SD Card inserted in the front slot of a Wii U</div>
+  <div>6. HDD or USB stick plugged to a USB port on a Wii U</div>
+  <div>&nbsp;</div>
+  <div>Only these methods have been verified by the Staff and enough testing has been conducted to ensure times set using them are identical to times set with a Disc.</div>
+  <div>&nbsp;</div>
+  <div>Rules regarding usage of the game:</div>
+  <div>&nbsp;</div>
+  <div>1. The F-Zero GX image file (ISO) must not be modified in any way. it must be the same image file obtained by reading a F-Zero GX game disc with software capable of creating a backup image of the game. this prevents any possible advantage provided by creating new visual or audio cues.</div>
+  <div>2. Additional proof for times will be required in the form of Replay files. through testing, it's been determined that Replay files will only sync with game versions that don't have any modifications to machine stats.&nbsp;this ensures players won't be editing the game's files. as a side effect, Story Mode times set on USB/SD Loaders won't be allowed because this form of proof can't be obtained from that mode.</div>
+  <div>3. USB/SD Loader software such as Nintendont usually comes with functionality for cheat codes. make sure they are turned off when setting times. you're allowed to unlock the Event Parts (Gold Parts) in the same way it is done with Action Replay.</div>
+  <p style=text-align:left>&nbsp;</p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>&nbsp;</span>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>Max Speed Ladder</span>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>1. Times in the GX Max Speed Ladder must be set at 100% Max Speed settings <strong>ONLY.</strong>
+      <br>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>2. No checkpoint skipping is allowed to be used in the Max Speed ladder. This includes the use of this shortcut on PRSLS: </span>
+    <font face=Verdana>
+      <a href=http://wrvids.com/F-Zero_series/F-Zero%20GX/prsls_midiman_nazo.mpg>
+        <span style=font-family:Arial>prsls_mts_shortcut.mpg</span>
+      </a>
+    </font>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>3. Quickturn alternations with custom machines with a body of E/D are banned, unless if it is naturally required by the track, either by a curve, or to align a certain position and angle. This rule has been done to prevent snaking with custom vehicles.</span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>4. Side Attacks are allowed to be used, but HSSA (Hyper Speed Side Attack) is not allowed.</span>
+  </p>
+  <p style=text-align:left>-</p>
+  <p>
+    <strong>(Not ladder rules!)</strong>&nbsp;- Below are the rules applied to the Non-Side Attack category displayed in the&nbsp; <a href="http://www.fzerocentral.org/viewtopic.php?t=13710">WR List</a>:
+  </p>
+  <ol>
+    <li>100% Max Speed settings ONLY.</li>
+    <li>No checkpoint skipping is allowed to be used in the Non-SA category. This includes the use of this shortcut on PRSLS: <font face=Verdana>
+        <a href=http://wrvids.com/F-Zero_series/F-Zero%20GX/prsls_midiman_nazo.mpg>
+          <span style=font-family:Arial>prsls_mts_shortcut.mpg</span>
+        </a>
+      </font>
+    </li>
+    <li>Side Attacks are not allowed.</li>
+    <li>Machines with a body rating of E or D are not allowed.</li>
+  </ol>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>Snaking Ladder</span>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>1. Times in the GX Snaking Ladder must be set at 0% (Max Acceleration) settings <strong>ONLY.</strong>
+    </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>2. No checkpoint skipping is allowed to be used in the Snaking ladder. This includes the use of this shortcut on PRSLS:&nbsp;</span>
+    <font face=Verdana>
+      <a href=http://wrvids.com/F-Zero_series/F-Zero%20GX/prsls_midiman_nazo.mpg>
+        <span style=font-family:Arial>prsls_mts_shortcut.mpg</span>
+      </a>
+    </font>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>3. Snaking patterns in the air are only allowed to be performed <strong>ONCE</strong>&nbsp;when using a machine that weighs less than 2050kg. This has been done to prevent unintentional flying. </span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>4. Flying through the whole course, even without skipping checkpoints, is prohibited.</span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>5. Side Attacks are allowed to be used, but HSSA (Hyper Speed Side Attack) is not allowed.</span>
+  </p>
+  <hr>
+  <p style=text-align:center>&nbsp; <span style=font-family:Arial></span>
+    <span style=font-size:x-large>Open Ladder</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>1. Times in the GX Open Ladder can be set at any setting. This ladder allows the use of Snaking, Space Flying, and Non-Snaking. </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>2.&nbsp;Checkpoint skipping is also allowed in this ladder.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial></span>
+  </p>
+  <p>
+    <span style=font-family:Arial>3. HSSA (Hyper Speed Side Attack) is allowed in this ladder.</span>
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+    </span>
+  </p>
+  <p style=text-align:center>
+    <span style=font-family:Arial>In order to have an FZC Best or World Record to be accepted to FZC, one must follow the requirements of "full video proof". If an FZC Best/WR does not adhere to the requirements listed for "full video proof", the time is subject to immediate removal from the ladder.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>Requirements of "Full Video Proof":</span>
+  </p>
+  <ol>
+    <li>
+      <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
+    </li>
+    <li>
+      <span style=font-family:Arial>The video <u>should</u> display the ending stats from the race after it is ove <span style=color:rgb(0,0,0)>r.</span>
+      </span>
+    </li>
+    <li>
+      <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
+    </li>
+    <li>
+      <span style=font-family:Arial>
+        <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video from public, FZC witholds the right to take down your time associated with that video.</span>
+      </span>
+    </li>
+  </ol>
+  <p>
+    <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013, does not need to adhere by the requirements of "Full Video Proof".</span>
+  </p>
+  <hr>
+  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
+    </span>
+  </p>
+  <p style=background-color:rgb(247,247,247)>
+    <font face=Arial>
+      <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
+    </font>
+    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
+      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+    </a>
+  </p>
+  <p>
+    <strong>-UPDATE- 15th September 2014:</strong>
+  </p>
+  <p>As of the 15th of September 2014, the replay mode cannot be used as a proof for FZC Bests/World Records anymore. (Explanation given on this page: <a href="http://www.fzerocentral.org/viewtopic.php?t=13926&amp;start=0">http://www.fzerocentral.org/viewtopic.php?t=13926&amp;start=0</a>) </p>
+  <p>The updated rules requires the WR player to do one of the following options:</p>
+  <ol>
+    <li>Make a live recording. Video example: <a href="https://www.youtube.com/watch?v=FDrXT_nRS_E">https://www.youtube.com/watch?v=FDrXT_nRS_E</a>
+    </li>
+    <li>Make a recording that starts from the results screen (with the lap splits and such), and ends after the "instant replay mode" (replay mode with the replay icon shown at the bottom left of the screen). Video Example: <a href="https://www.youtube.com/watch?v=E5sRMcSmLGs">https://www.youtube.com/watch?v=E5sRMcSmLGs</a>
+    </li>
+  </ol>
+  <p>If for whatever reason, suspicion were to occur from the above method of providing proof, further proof (such as streaming) could get requested.</p>
+  <p>*NOTE: FZC Bests/World Records that used the replay mode as a proof before the 15th of September 2014 are still valid as FZC Bests/World Records.</p>
+  <p>&nbsp;</p>
+  <p>
+    <strong>-UPDATE- 15th August 2015:</strong>
+  </p>
+  <p>As of the 15th of August 2015, the Max Speed rules have been amended to clarify the use of quick turns in straight roads to prevent deliberate Snaking in 100% Max Speed settings and to make things more clear overall.</p>
+  <p>&nbsp;</p>
+  <p>
+    <strong>-UPDATE- 5th September 2017:</strong>
+  </p>
+  <p>Added a rule for all three ladders to clarify which game modes can be used: "Course Times and Speeds must be obtained using Time Attack mode. Lap Times must be obtained with either Time Attack mode or Practice mode with CPUs off."</p>
+  <p>Removed "Only submit times that are shown on your records screen." sentence from the "individual competition" rule. Having times saved to your memory card is not a requirement since (1) Spaceflying times below 20 seconds may not save due to a glitch, and (2) Lap Times achieved in Practice mode don't get saved.</p>
+  <p>&nbsp;</p>
+  <p>
+    <strong>-UPDATE- 17th June 2018:</strong>
+  </p>
+  <p>As of the 17th of June 2018, USB Loaders are allowed to use for setting Course Times and Fast Laps.</p>
+  <p>old rules that prohibited the use of ISOs were removed.</p>
+  <p>&nbsp;</p>
+  <p>
+    <strong>-UPDATE- 17th January 2021:</strong>
+  </p>
+  <p>
+    <span style=font-family:Arial>Banned two exploits that take advantage of the Restore feature in Practice Mode that allows to set fast lap times that would not be possible to do in Time Attack mode:</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>"If you have the Restore feature turned on in practice mode to set a fast lap, the following exploits cannot be used</span>
+  </p>
+  <ul>
+    <li>
+      <span style=font-family:Arial>Going out of bounds before completing a lap, but still complete the lap as the machine is being restored -&nbsp;</span>
+      <a href="https://www.youtube.com/watch?v=jTdh8jtV9vQ">
+        <span style=font-family:Arial>Video Demonstration</span>
+      </a>
+    </li>
+    <li>
+      <span style=font-family:Arial>Falling off course immediately after the lap begins in a specific way that makes the machine be restored right before the start/finish line, completing the lap in potentially under 4 seconds -&nbsp;</span>
+      <a href="https://www.youtube.com/watch?v=4DO1HFK9j_c">
+        <span style=font-family:Arial>Video Demonstration</span>
+      </a>
+      <span style=font-family:Arial>"</span>
+    </li>
+  </ul>
+  <p>&nbsp;</p>
+  <p>
+    <strong>-UPDATE- 23rd March 2021:</strong>
+  </p>
+  <p>added GCLoader to the allowed USB/SD Loader methods</p>
+  <p>changed "USB Loader" to "USB/SD Loader" for better acurracy</p>
+  <p>&nbsp;</p>
+</div>
+{% endblock %}

--- a/templates/rules/gx.html
+++ b/templates/rules/gx.html
@@ -12,13 +12,8 @@
   <span style=font-family:Arial></span>
 </p>
 <p align=center>
-  <u>
-    <strong>
-      <span style=font-family:Arial>Last Updated:</span>
-    </strong>
-  </u>
   <strong>
-    <span style=font-family:Arial>&nbsp;23rd March 2021</span>
+    <span style=font-family:Arial>Last Updated: 23rd March 2021</span>
   </strong>
 </p>
 <hr>

--- a/templates/rules/mv.html
+++ b/templates/rules/mv.html
@@ -1,103 +1,101 @@
-{% extends 'base.html' %}
+{% extends 'rules/base.html' %}
 
-{% block content %}
-<div class=rules-text>
-  <p align=center>
-    <span style=font-family:Arial>
-      <span style=font-size:xx-large>
-        <strong>F-Zero Central F-ZERO Maximum Velocity Time Submission Rules</strong>
-      </span>
+{% block rules_content %}
+<p align=center>
+  <span style=font-family:Arial>
+    <span style=font-size:xx-large>
+      <strong>F-Zero Central F-ZERO Maximum Velocity Time Submission Rules</strong>
     </span>
-  </p>
-  <p>
-    <span style=font-family:Arial></span>
-  </p>
-  <p align=center>
-    <span style=font-family:Arial>Last Updated: 26 May 2020</span>
-  </p>
-  <hr>
-  <p>
-    <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>2. Times set on Maximum Velocity using the multiplayer link are not allowed to be submitted on FZC. The reason&nbsp;is due to the chance to gain a large amount of "speed bumps" by your friend which would&nbsp;enable you to get a faster time than is possible when racing against the COM.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>3. Players are reminded that FZC only accepts times set with the game cartridge,&nbsp;</span>
-    <span style=font-family:Arial>Flash cartridge ("Flashcart") with an unaltered ROM of the original game, the 3DS Ambassador Program version</span>
-    <span style=font-family:Arial>&nbsp;and the Wii U Virtual Console version.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>4. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for teams. Only submit times that are shown on your records screen.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>5. The use of cheat devices such as Action Replay are forbidden on the ladder. Restore points on the Wii U VC </span>
-    <span style=font-family:Arial>and Flash cartridge (if that's a possibility) are not to be misused*. If it is suspected that any cheat devices have been used and/or restore points have been misused, that player will have their times removed from the ladder.&nbsp;</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>6. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>7. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>8. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>*Restore points may only be used to attempt fast laps and for infinite lives in Grand Prix mode. This means you can set a restore point <strong>before</strong>
-      <strong>entering</strong> a fast lap or you can set a restore point <strong>before</strong>
-      <strong>the timer</strong> in a five lap race <strong>starts</strong>. Misuse of restore points constitutes as using a restore point <strong>after entering</strong> a fast lap or <strong>after the timer</strong> of a five lap race <strong> starts</strong>. Even if a restore point is activated in only the first frame of the fast lap or five lap, your time will be removed, no exceptions. If a player is found abusing the restore point mechanic, their times will be subject to immediate removal from the ladder. </span>
-  </p>
-  <hr>
-  <p style=text-align:center>
+  </span>
+</p>
+<p>
+  <span style=font-family:Arial></span>
+</p>
+<p align=center>
+  <span style=font-family:Arial>Last Updated: 26 May 2020</span>
+</p>
+<hr>
+<p>
+  <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</span>
+</p>
+<p>
+  <span style=font-family:Arial>2. Times set on Maximum Velocity using the multiplayer link are not allowed to be submitted on FZC. The reason&nbsp;is due to the chance to gain a large amount of "speed bumps" by your friend which would&nbsp;enable you to get a faster time than is possible when racing against the COM.</span>
+</p>
+<p>
+  <span style=font-family:Arial>3. Players are reminded that FZC only accepts times set with the game cartridge,&nbsp;</span>
+  <span style=font-family:Arial>Flash cartridge ("Flashcart") with an unaltered ROM of the original game, the 3DS Ambassador Program version</span>
+  <span style=font-family:Arial>&nbsp;and the Wii U Virtual Console version.</span>
+</p>
+<p>
+  <span style=font-family:Arial>4. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for teams. Only submit times that are shown on your records screen.</span>
+</p>
+<p>
+  <span style=font-family:Arial>5. The use of cheat devices such as Action Replay are forbidden on the ladder. Restore points on the Wii U VC </span>
+  <span style=font-family:Arial>and Flash cartridge (if that's a possibility) are not to be misused*. If it is suspected that any cheat devices have been used and/or restore points have been misused, that player will have their times removed from the ladder.&nbsp;</span>
+</p>
+<p>
+  <span style=font-family:Arial>6. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff.</span>
+</p>
+<p>
+  <span style=font-family:Arial>7. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
+</p>
+<p>
+  <span style=font-family:Arial>8. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
+</p>
+<p>
+  <span style=font-family:Arial>*Restore points may only be used to attempt fast laps and for infinite lives in Grand Prix mode. This means you can set a restore point <strong>before</strong>
+    <strong>entering</strong> a fast lap or you can set a restore point <strong>before</strong>
+    <strong>the timer</strong> in a five lap race <strong>starts</strong>. Misuse of restore points constitutes as using a restore point <strong>after entering</strong> a fast lap or <strong>after the timer</strong> of a five lap race <strong> starts</strong>. Even if a restore point is activated in only the first frame of the fast lap or five lap, your time will be removed, no exceptions. If a player is found abusing the restore point mechanic, their times will be subject to immediate removal from the ladder. </span>
+</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+  </span>
+</p>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>
+      <span style=font-size:small>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof.</span>
+    </span> If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*. </span>
+</p>
+<p>
+  <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
+</p>
+<ol>
+  <li>
+    <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
+  </li>
+  <li>
+    <span style=font-family:Arial>The video must display the ending stats from the race after it is over (this rule is an exception for GX players who cannot do this if using the replay feature).</span>
+  </li>
+  <li>
+    <span style=font-family:Arial>The video must display the time set by showing it in the records menu.</span>
+  </li>
+  <li>
+    <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
+  </li>
+  <li>
     <span style=font-family:Arial>
-      <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+      <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any too see, FZC witholds the right to take down your time associated with that video.</span>
     </span>
-  </p>
-  <p style=text-align:center>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>
-        <span style=font-size:small>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof.</span>
-      </span> If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*. </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
-  </p>
-  <ol>
-    <li>
-      <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
-    </li>
-    <li>
-      <span style=font-family:Arial>The video must display the ending stats from the race after it is over (this rule is an exception for GX players who cannot do this if using the replay feature).</span>
-    </li>
-    <li>
-      <span style=font-family:Arial>The video must display the time set by showing it in the records menu.</span>
-    </li>
-    <li>
-      <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
-    </li>
-    <li>
-      <span style=font-family:Arial>
-        <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any too see, FZC witholds the right to take down your time associated with that video.</span>
-      </span>
-    </li>
-  </ol>
-  <p>
-    <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
-  </p>
-  <hr>
-  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
-    </span>
-  </p>
-  <p style=background-color:rgb(247,247,247)>
-    <font face=Arial>
-      <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
-    </font>
-    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
-      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-    </a>
-  </p>
-</div>
+  </li>
+</ol>
+<p>
+  <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
+</p>
+<hr>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
+  </span>
+</p>
+<p style=background-color:rgb(247,247,247)>
+  <font face=Arial>
+    <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
+  </font>
+  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
+    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+  </a>
+</p>
 {% endblock %}

--- a/templates/rules/mv.html
+++ b/templates/rules/mv.html
@@ -1,0 +1,103 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class=rules-text>
+  <p align=center>
+    <span style=font-family:Arial>
+      <span style=font-size:xx-large>
+        <strong>F-Zero Central F-ZERO Maximum Velocity Time Submission Rules</strong>
+      </span>
+    </span>
+  </p>
+  <p>
+    <span style=font-family:Arial></span>
+  </p>
+  <p align=center>
+    <span style=font-family:Arial>Last Updated: 26 May 2020</span>
+  </p>
+  <hr>
+  <p>
+    <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>2. Times set on Maximum Velocity using the multiplayer link are not allowed to be submitted on FZC. The reason&nbsp;is due to the chance to gain a large amount of "speed bumps" by your friend which would&nbsp;enable you to get a faster time than is possible when racing against the COM.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>3. Players are reminded that FZC only accepts times set with the game cartridge,&nbsp;</span>
+    <span style=font-family:Arial>Flash cartridge ("Flashcart") with an unaltered ROM of the original game, the 3DS Ambassador Program version</span>
+    <span style=font-family:Arial>&nbsp;and the Wii U Virtual Console version.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>4. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for teams. Only submit times that are shown on your records screen.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>5. The use of cheat devices such as Action Replay are forbidden on the ladder. Restore points on the Wii U VC </span>
+    <span style=font-family:Arial>and Flash cartridge (if that's a possibility) are not to be misused*. If it is suspected that any cheat devices have been used and/or restore points have been misused, that player will have their times removed from the ladder.&nbsp;</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>6. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>7. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>8. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>*Restore points may only be used to attempt fast laps and for infinite lives in Grand Prix mode. This means you can set a restore point <strong>before</strong>
+      <strong>entering</strong> a fast lap or you can set a restore point <strong>before</strong>
+      <strong>the timer</strong> in a five lap race <strong>starts</strong>. Misuse of restore points constitutes as using a restore point <strong>after entering</strong> a fast lap or <strong>after the timer</strong> of a five lap race <strong> starts</strong>. Even if a restore point is activated in only the first frame of the fast lap or five lap, your time will be removed, no exceptions. If a player is found abusing the restore point mechanic, their times will be subject to immediate removal from the ladder. </span>
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+    </span>
+  </p>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>
+        <span style=font-size:small>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof.</span>
+      </span> If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*. </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
+  </p>
+  <ol>
+    <li>
+      <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
+    </li>
+    <li>
+      <span style=font-family:Arial>The video must display the ending stats from the race after it is over (this rule is an exception for GX players who cannot do this if using the replay feature).</span>
+    </li>
+    <li>
+      <span style=font-family:Arial>The video must display the time set by showing it in the records menu.</span>
+    </li>
+    <li>
+      <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
+    </li>
+    <li>
+      <span style=font-family:Arial>
+        <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any too see, FZC witholds the right to take down your time associated with that video.</span>
+      </span>
+    </li>
+  </ol>
+  <p>
+    <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
+  </p>
+  <hr>
+  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
+    </span>
+  </p>
+  <p style=background-color:rgb(247,247,247)>
+    <font face=Arial>
+      <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
+    </font>
+    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
+      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+    </a>
+  </p>
+</div>
+{% endblock %}

--- a/templates/rules/mv.html
+++ b/templates/rules/mv.html
@@ -85,17 +85,14 @@
   <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
 </p>
 <hr>
-<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;text-align:center'>
   <span style=font-family:Arial>
     <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
   </span>
 </p>
-<p style=background-color:rgb(247,247,247)>
-  <font face=Arial>
-    <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
-  </font>
-  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
-    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-  </a>
+<p>
+  <span style=font-family:Arial>
+    <a href="/guidelines.php" target=_blank>Read here</a> - these are not enforceable rules, but guidelines for all players to follow.
+  </span>
 </p>
 {% endblock %}

--- a/templates/rules/snes.html
+++ b/templates/rules/snes.html
@@ -1,0 +1,83 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class=rules-text>
+  <p align=center>
+    <span style=font-size:xx-large>
+      <strong>F-ZERO Central F-ZERO SNES Time Submission Rules</strong>
+    </span>
+  </p>
+  <p align=center>Last Updated: 23 Mar 2021</p>
+  <hr>
+  <p style=text-align:left>&nbsp;(Note: The use of the phrase "save state" in the following text refers to any kind of save state from a SNES/SFC game saver, restore point from a WiiUVC, and suspend point from a SNES/SFC Mini and Nintendo Switch SNES App)</p>
+  <p style=text-align:left>Any players who do not adhere to the following rules are subject to having their times removed from the ladder.</p>
+  <p align=center>
+    <font size=5>Basic Ladder Rules</font>
+  </p>
+  <p>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</p>
+  <p>2. FZC only accepts times set on the Super Nintendo Entertainment System/ Super Famicom, Wii Virtual Console, WiiU Virtual Console, 3DS Virtual Console, SNES/SFC Mini and Nintendo Switch Online service SNES App versions of the game. Flashcarts are allowed for the SNES version for savestate usage and times using this have to follow the savestate rules.</p>
+  <p>3. The use of cheat devices such as Action Replay, Game Genie, ect. are forbidden on the ladder.</p>
+  <p>4. Multiple accounts for the same player are not allowed, neither are joint accounts.</p>
+  <p>5. On the NTSC version of the game (This rule does not apply to the PAL version), pausing during the middle of a run is not allowed. For fast laps, pausing the game before entering the lap is fine. The reason for this rule is explained in greater detail <a href="http://www.fzerocentral.org/viewtopic.php?t=13945">here</a>. This rule only applies to times set after 5 November 2014. </p>
+  <p>6. Finally, NO CHEATING of any kind will be tolerated. If you are found to be cheating, it will result in immediate removal of all your times from the SNES ladder. Any other times you have submitted to FZC will also be subject to removal.</p>
+  <p style=text-align:center>
+    <span style=font-size:x-large>Save State Rules for Runs Submitted to Ladder <br>
+    </span>
+  </p>
+  <p style=text-align:center>For practice, save states may be used however a player likes. However when submitting runs to the FZC ladder or for WR, save states may only be used as described below. If save states are used anywhere else other than as described below, the player doing so will have their associated time removed.</p>
+  <p style=text-align:center>
+    <span style=font-size:large>5-Laps</span>
+  </p>
+  <p>1. Before the timer of the 5-lap attempt first starts.</p>
+  <p style=text-align:center>
+    <span style=font-size:large>Fast Laps</span>
+  </p>
+  <p style=text-align:left>1. Before any S-Jet is activated that leads into the fast lap being attempted. <br>
+    <br> 2. For DEATH WIND I, DEATH WIND II, and FIRE FIELD: Before touching the arrow leading into the lap. With that, the save state may only be set before enterting the fast lap and must be set in such a way that the player must be required to give the machine input to move it into the arrow after activating the save state. (i.e. if a save state is activated and the machine can move into the arrow without input, then the fast lap is void). Also, unpausing the game does not constitute as giving the machine input.
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+  </p>
+  <p style=text-align:center>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of 'full video proof' defined below. If a FZC Best/WR does not adhere to the requirements listed for 'full video proof,' the time is subject to immediate removal from the ladder**.</p>
+  <p>A video submission that qualifies as 'full video proof' must meet all the following requirements:</p>
+  <ol>
+    <li>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. If recording fast laps without save states, in general try to show around half a second before the first S-Jet is activated. For DWI, DWII, and FF, try to show around 2 seconds before hitting the arrow. </li>
+    <li>The video must display the ending stats from the race after it is over.</li>
+    <li>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</li>
+    <li>
+      <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any to see, FZC reserves the right to take down your time associated with that video.</span>
+    </li>
+  </ol>
+  <p>Extra rules for players using save states for fast laps:</p>
+  <p>Use of a save state must be shown in the recording before the start of the lap: <br> -for SNES/SFC game savers, this means showing the frame before activation of the save state, which is generally a black screen <br> -for the WiiUVC, this means showing the main menu where the restore point is activated <br> -for the SNES Mini, this means showing the home menu where you select the suspend point <br> -for the Nintendo Switch Online SNES App, this means showing the Save States Menu before picking the corresponding Save State </p>
+  <p style=text-align:left>**FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'full video proof.' <span style=font-family:Arial>
+      <br>
+    </span>
+  </p>
+  <hr>
+  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
+    </span>
+  </p>
+  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247)'>
+    <span style=font-family:Arial>The following are not enforceable rules, but guidelines for all players to follow:&nbsp;</span>
+    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style=background:transparent;color:rgb(61,106,147)>
+      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+    </a>
+  </p>
+  <p>&nbsp;</p>
+  <hr>
+  <p>
+    <span style=font-size:small>Edit notes: <br type=_moz>
+    </span>
+  </p>
+  <ul>
+    <li>
+      <span style=font-size:small>28 Aug 2020: Improved wording on the 'public video proof' rule.</span>
+    </li>
+    <li>23 Mar 2021: added "Flashcart" to the accepted methods officially.</li>
+  </ul>
+</div>
+{% endblock %}

--- a/templates/rules/snes.html
+++ b/templates/rules/snes.html
@@ -55,16 +55,15 @@
   </span>
 </p>
 <hr>
-<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;text-align:center'>
   <span style=font-family:Arial>
     <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
   </span>
 </p>
-<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247)'>
-  <span style=font-family:Arial>The following are not enforceable rules, but guidelines for all players to follow:&nbsp;</span>
-  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style=background:transparent;color:rgb(61,106,147)>
-    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-  </a>
+<p>
+  <span style=font-family:Arial>
+    <a href="/guidelines.php" target=_blank>Read here</a> - these are not enforceable rules, but guidelines for all players to follow.
+  </span>
 </p>
 <p>&nbsp;</p>
 <hr>

--- a/templates/rules/snes.html
+++ b/templates/rules/snes.html
@@ -1,83 +1,81 @@
-{% extends 'base.html' %}
+{% extends 'rules/base.html' %}
 
-{% block content %}
-<div class=rules-text>
-  <p align=center>
-    <span style=font-size:xx-large>
-      <strong>F-ZERO Central F-ZERO SNES Time Submission Rules</strong>
-    </span>
-  </p>
-  <p align=center>Last Updated: 23 Mar 2021</p>
-  <hr>
-  <p style=text-align:left>&nbsp;(Note: The use of the phrase "save state" in the following text refers to any kind of save state from a SNES/SFC game saver, restore point from a WiiUVC, and suspend point from a SNES/SFC Mini and Nintendo Switch SNES App)</p>
-  <p style=text-align:left>Any players who do not adhere to the following rules are subject to having their times removed from the ladder.</p>
-  <p align=center>
-    <font size=5>Basic Ladder Rules</font>
-  </p>
-  <p>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</p>
-  <p>2. FZC only accepts times set on the Super Nintendo Entertainment System/ Super Famicom, Wii Virtual Console, WiiU Virtual Console, 3DS Virtual Console, SNES/SFC Mini and Nintendo Switch Online service SNES App versions of the game. Flashcarts are allowed for the SNES version for savestate usage and times using this have to follow the savestate rules.</p>
-  <p>3. The use of cheat devices such as Action Replay, Game Genie, ect. are forbidden on the ladder.</p>
-  <p>4. Multiple accounts for the same player are not allowed, neither are joint accounts.</p>
-  <p>5. On the NTSC version of the game (This rule does not apply to the PAL version), pausing during the middle of a run is not allowed. For fast laps, pausing the game before entering the lap is fine. The reason for this rule is explained in greater detail <a href="http://www.fzerocentral.org/viewtopic.php?t=13945">here</a>. This rule only applies to times set after 5 November 2014. </p>
-  <p>6. Finally, NO CHEATING of any kind will be tolerated. If you are found to be cheating, it will result in immediate removal of all your times from the SNES ladder. Any other times you have submitted to FZC will also be subject to removal.</p>
-  <p style=text-align:center>
-    <span style=font-size:x-large>Save State Rules for Runs Submitted to Ladder <br>
-    </span>
-  </p>
-  <p style=text-align:center>For practice, save states may be used however a player likes. However when submitting runs to the FZC ladder or for WR, save states may only be used as described below. If save states are used anywhere else other than as described below, the player doing so will have their associated time removed.</p>
-  <p style=text-align:center>
-    <span style=font-size:large>5-Laps</span>
-  </p>
-  <p>1. Before the timer of the 5-lap attempt first starts.</p>
-  <p style=text-align:center>
-    <span style=font-size:large>Fast Laps</span>
-  </p>
-  <p style=text-align:left>1. Before any S-Jet is activated that leads into the fast lap being attempted. <br>
-    <br> 2. For DEATH WIND I, DEATH WIND II, and FIRE FIELD: Before touching the arrow leading into the lap. With that, the save state may only be set before enterting the fast lap and must be set in such a way that the player must be required to give the machine input to move it into the arrow after activating the save state. (i.e. if a save state is activated and the machine can move into the arrow without input, then the fast lap is void). Also, unpausing the game does not constitute as giving the machine input.
-  </p>
-  <hr>
-  <p style=text-align:center>
-    <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
-  </p>
-  <p style=text-align:center>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of 'full video proof' defined below. If a FZC Best/WR does not adhere to the requirements listed for 'full video proof,' the time is subject to immediate removal from the ladder**.</p>
-  <p>A video submission that qualifies as 'full video proof' must meet all the following requirements:</p>
-  <ol>
-    <li>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. If recording fast laps without save states, in general try to show around half a second before the first S-Jet is activated. For DWI, DWII, and FF, try to show around 2 seconds before hitting the arrow. </li>
-    <li>The video must display the ending stats from the race after it is over.</li>
-    <li>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</li>
-    <li>
-      <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any to see, FZC reserves the right to take down your time associated with that video.</span>
-    </li>
-  </ol>
-  <p>Extra rules for players using save states for fast laps:</p>
-  <p>Use of a save state must be shown in the recording before the start of the lap: <br> -for SNES/SFC game savers, this means showing the frame before activation of the save state, which is generally a black screen <br> -for the WiiUVC, this means showing the main menu where the restore point is activated <br> -for the SNES Mini, this means showing the home menu where you select the suspend point <br> -for the Nintendo Switch Online SNES App, this means showing the Save States Menu before picking the corresponding Save State </p>
-  <p style=text-align:left>**FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'full video proof.' <span style=font-family:Arial>
-      <br>
-    </span>
-  </p>
-  <hr>
-  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
-    </span>
-  </p>
-  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247)'>
-    <span style=font-family:Arial>The following are not enforceable rules, but guidelines for all players to follow:&nbsp;</span>
-    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style=background:transparent;color:rgb(61,106,147)>
-      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-    </a>
-  </p>
-  <p>&nbsp;</p>
-  <hr>
-  <p>
-    <span style=font-size:small>Edit notes: <br type=_moz>
-    </span>
-  </p>
-  <ul>
-    <li>
-      <span style=font-size:small>28 Aug 2020: Improved wording on the 'public video proof' rule.</span>
-    </li>
-    <li>23 Mar 2021: added "Flashcart" to the accepted methods officially.</li>
-  </ul>
-</div>
+{% block rules_content %}
+<p align=center>
+  <span style=font-size:xx-large>
+    <strong>F-ZERO Central F-ZERO SNES Time Submission Rules</strong>
+  </span>
+</p>
+<p align=center>Last Updated: 23 Mar 2021</p>
+<hr>
+<p style=text-align:left>&nbsp;(Note: The use of the phrase "save state" in the following text refers to any kind of save state from a SNES/SFC game saver, restore point from a WiiUVC, and suspend point from a SNES/SFC Mini and Nintendo Switch SNES App)</p>
+<p style=text-align:left>Any players who do not adhere to the following rules are subject to having their times removed from the ladder.</p>
+<p align=center>
+  <font size=5>Basic Ladder Rules</font>
+</p>
+<p>1. Turbo Controllers are banned from being used on the Ladder as they present the player with an unfair advantage. Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</p>
+<p>2. FZC only accepts times set on the Super Nintendo Entertainment System/ Super Famicom, Wii Virtual Console, WiiU Virtual Console, 3DS Virtual Console, SNES/SFC Mini and Nintendo Switch Online service SNES App versions of the game. Flashcarts are allowed for the SNES version for savestate usage and times using this have to follow the savestate rules.</p>
+<p>3. The use of cheat devices such as Action Replay, Game Genie, ect. are forbidden on the ladder.</p>
+<p>4. Multiple accounts for the same player are not allowed, neither are joint accounts.</p>
+<p>5. On the NTSC version of the game (This rule does not apply to the PAL version), pausing during the middle of a run is not allowed. For fast laps, pausing the game before entering the lap is fine. The reason for this rule is explained in greater detail <a href="http://www.fzerocentral.org/viewtopic.php?t=13945">here</a>. This rule only applies to times set after 5 November 2014. </p>
+<p>6. Finally, NO CHEATING of any kind will be tolerated. If you are found to be cheating, it will result in immediate removal of all your times from the SNES ladder. Any other times you have submitted to FZC will also be subject to removal.</p>
+<p style=text-align:center>
+  <span style=font-size:x-large>Save State Rules for Runs Submitted to Ladder <br>
+  </span>
+</p>
+<p style=text-align:center>For practice, save states may be used however a player likes. However when submitting runs to the FZC ladder or for WR, save states may only be used as described below. If save states are used anywhere else other than as described below, the player doing so will have their associated time removed.</p>
+<p style=text-align:center>
+  <span style=font-size:large>5-Laps</span>
+</p>
+<p>1. Before the timer of the 5-lap attempt first starts.</p>
+<p style=text-align:center>
+  <span style=font-size:large>Fast Laps</span>
+</p>
+<p style=text-align:left>1. Before any S-Jet is activated that leads into the fast lap being attempted. <br>
+  <br> 2. For DEATH WIND I, DEATH WIND II, and FIRE FIELD: Before touching the arrow leading into the lap. With that, the save state may only be set before enterting the fast lap and must be set in such a way that the player must be required to give the machine input to move it into the arrow after activating the save state. (i.e. if a save state is activated and the machine can move into the arrow without input, then the fast lap is void). Also, unpausing the game does not constitute as giving the machine input.
+</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+</p>
+<p style=text-align:center>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of 'full video proof' defined below. If a FZC Best/WR does not adhere to the requirements listed for 'full video proof,' the time is subject to immediate removal from the ladder**.</p>
+<p>A video submission that qualifies as 'full video proof' must meet all the following requirements:</p>
+<ol>
+  <li>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. If recording fast laps without save states, in general try to show around half a second before the first S-Jet is activated. For DWI, DWII, and FF, try to show around 2 seconds before hitting the arrow. </li>
+  <li>The video must display the ending stats from the race after it is over.</li>
+  <li>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</li>
+  <li>
+    <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any to see, FZC reserves the right to take down your time associated with that video.</span>
+  </li>
+</ol>
+<p>Extra rules for players using save states for fast laps:</p>
+<p>Use of a save state must be shown in the recording before the start of the lap: <br> -for SNES/SFC game savers, this means showing the frame before activation of the save state, which is generally a black screen <br> -for the WiiUVC, this means showing the main menu where the restore point is activated <br> -for the SNES Mini, this means showing the home menu where you select the suspend point <br> -for the Nintendo Switch Online SNES App, this means showing the Save States Menu before picking the corresponding Save State </p>
+<p style=text-align:left>**FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'full video proof.' <span style=font-family:Arial>
+    <br>
+  </span>
+</p>
+<hr>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
+  </span>
+</p>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247)'>
+  <span style=font-family:Arial>The following are not enforceable rules, but guidelines for all players to follow:&nbsp;</span>
+  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style=background:transparent;color:rgb(61,106,147)>
+    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+  </a>
+</p>
+<p>&nbsp;</p>
+<hr>
+<p>
+  <span style=font-size:small>Edit notes: <br type=_moz>
+  </span>
+</p>
+<ul>
+  <li>
+    <span style=font-size:small>28 Aug 2020: Improved wording on the 'public video proof' rule.</span>
+  </li>
+  <li>23 Mar 2021: added "Flashcart" to the accepted methods officially.</li>
+</ul>
 {% endblock %}

--- a/templates/rules/x.html
+++ b/templates/rules/x.html
@@ -1,0 +1,213 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class=rules-text>
+  <p align=center>
+    <strong>
+      <span style=font-size:xx-large>
+        <span style=font-family:Arial>&nbsp; F-Zero Central F-ZERO X Time Submission Rules</span>
+      </span>
+    </strong>
+  </p>
+  <p>
+    <span style=font-family:Arial></span>
+  </p>
+  <p align=center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>
+        <span style=font-size:xx-large>
+          <span style=font-size:small>Last Updated: 11 April 2020</span>
+        </span>
+      </span>
+    </span>
+  </p>
+  <hr>
+  <p style=text-align:center>&nbsp; <span style=font-family:Arial></span>
+    <span style=font-size:x-large>Rules for all F-Zero X Ladders</span>
+  </p>
+  <p>&nbsp; <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the FZX Ladder as they present the player with an unfair advantage. <strong>Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</strong>
+    </span>
+    <span style=font-family:Arial></span>
+  </p>
+  <p>
+    <span style=font-family:Arial>2. Players are reminded that FZC only accepts times set with the game cartridge, the Wii Virtual Console version and the Wii U Virtual Console version. There shall be no exceptions made for allowing people to submit times set using a ROM. Any times that are found to have been set using a ROM will be deleted. </span>
+  </p>
+  <p>
+    <span style=font-family:Arial></span>
+  </p>
+  <p>
+    <span style=font-family:Arial>3. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for team</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>4. The use of cheat devices such as Action Replay are forbidden on the ladder. If it is suspected that a cheat device has been used then that player will have their times removed from the ladder.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>5. Modifying and/or tinkering with the hardware to improve your times&nbsp;is prohibited. things like the Crooked Cartridge glitch (pulling the cart out a bit&nbsp;from the N64 while still playing) and altering the controllers with things such as Lego to make a turbo button&nbsp;are banned. if you have times set using these kind of modifications, they should be changed inmediately.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>6. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff.&nbsp;</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>7. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>8. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
+    <span style=font-family:Arial>
+      <br>
+    </span>
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-size:x-large>Save State Rules for Runs Submitted to Ladder <br>
+    </span>
+  </p>
+  <p style=text-align:center>For practice, save states may be used however a player likes. However when submitting runs to the FZC ladder or for WR, save states may only be used as described below. If save states are used anywhere else other than as described below, the player doing so will have their associated time removed.</p>
+  <p>
+    <span style=font-size:large>3-Laps</span>
+  </p>
+  <p>Before the timer of the 3-lap attempt first starts.</p>
+  <p>
+    <span style=font-size:large>Fast Laps</span>
+  </p>
+  <p>Before Boost Power and/or any advanced technique is performed that leads into the fast lap being attempted (example: the save state must be set before starting the AGG setup for a fast lap)</p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>Normal X ladder and Death Race Ladder Rules</span>
+      <br>
+    </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>1. Any engine settings may be used. <br>
+    </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>2. You may only use the normal 30 vehicles.&nbsp; You may not use the Super Falcon, Super Stingray, Super Cat, or any custom vehicles.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>3. Any glitches/techniques may be used except for pulling the corner of the N64 cartridge.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>4. Only submit times that are shown on your records screen. <br>
+    </span>
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>Expansion Kit Ladder Rules</span>
+      <br>
+    </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>1. All engine settings may be used.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>2. You may use any vehicle, including custom vehicles.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>3. Any glitches/techniques may be used except for pulling the corner of the N64 cartridge.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>4. Only submit times that are shown on your records screen.</span>
+  </p>
+  <div>&nbsp;</div>
+  <p>
+    <em>
+      <span style=font-family:Arial>Flashcart Rules</span>
+    </em>
+  </p>
+  <p>
+    <span style=font-family:Arial>Due to how difficult it is to obtain a 64DD and Expansion Kit and how much flash carts have advanced in the last decade, it's been decided that times set using one of these will be allowed with certain conditions:</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>1. You must use either an Everdrive 64 v2.5 or v3 or a 64Drive flash cart. these are the only ones tested by the community to work correctly with the FZX + EK combined rom.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>2. No cheat codes are allowed. the flash carts posses cheat code functionality but it should be avoided at any cost. patches aren't allowed either.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>3. Only the japanese FZX + EK rom is allowed. we want to ensure there's no difference between the game played on real hardware and played with the flash carts. using the unmodified combined rom is the closest to that. also, patching a normal FZX rom with EK tracks is not allowed since there's a couple of differences between the regular rom and the combined rom.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>4. When using a flash cart to set times, you must mention it in the comments section.</span>
+  </p>
+  <div>&nbsp;</div>
+  <p>
+    <span style=font-family:Arial>Proof will be handled in the same fashion as in the rest of the games. that means you need video proof if you get a WR time or very close to it.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>Video proof is important given the possibilities of modification, which means times set with a flashcart will be under tighter scrutiny.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>as a special note, it's still not allowed to use a flash cart with the regular tracks in the regular ladder.</span>
+  </p>
+  <hr>
+  <p style=text-align:center>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>Jumper Ladder Rules</span>
+      <br>
+    </span>
+  </p>
+  <p>
+    <span style=font-family:Arial>1. Only jumper engine settings may be used.&nbsp; This means that the engine setting on the pick-up graph has to be within four ticks of the right side of the graph.&nbsp; The area in red in the following diagram indicates the area allowed.</span>
+  </p>
+  <p>
+    <strong>I-i-i-i-i-i-i-I-i-i- <span style=color:rgb(255,0,0)>i-i-i-i-I</span>
+    </strong>
+  </p>
+  <p>
+    <span style=font-family:Arial>2. You may only use the normal 30 vehicles.&nbsp; You may not use the Super Falcon, Super Stingray, Super Cat, or any custom vehicles.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>3. Any glitches/techniques may be used except for pulling the corner of the N64 cartridge and the Air Ground Glitch.</span>
+  </p>
+  <p>
+    <span style=font-family:Arial>4. Only submit times that are shown on your records screen or on the results screen that is displayed at the end of a race. <br>
+    </span>
+  </p>
+  <hr>
+  <p style=text-align:center>&nbsp; <span style=font-family:Arial></span>
+    <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+  </p>
+  <p style=text-align:center>
+    <span style=font-family:Arial>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof. If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*.</span>
+  </p>
+  <p style=text-align:left>
+    <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
+  </p>
+  <ol>
+    <li>
+      <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
+    </li>
+    <li>
+      <span style=font-family:Arial>The video must display the ending stat</span>
+      <span style=font-family:Arial>s from the race after it is over.</span>
+    </li>
+    <li>
+      <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
+    </li>
+    <li>
+      <span style=font-family:Arial>
+        <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any too see, FZC witholds the right to take down your time associated with that video.</span>
+      </span>
+    </li>
+  </ol>
+  <p>
+    <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
+  </p>
+  <hr>
+  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+    <span style=font-family:Arial>
+      <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
+    </span>
+  </p>
+  <p style=background-color:rgb(247,247,247)>
+    <font face=Arial>
+      <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
+    </font>
+    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
+      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+    </a>
+  </p>
+</div>
+{% endblock %}

--- a/templates/rules/x.html
+++ b/templates/rules/x.html
@@ -195,17 +195,14 @@
   <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
 </p>
 <hr>
-<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;text-align:center'>
   <span style=font-family:Arial>
     <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
   </span>
 </p>
-<p style=background-color:rgb(247,247,247)>
-  <font face=Arial>
-    <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
-  </font>
-  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
-    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-  </a>
+<p>
+  <span style=font-family:Arial>
+    <a href="/guidelines.php" target=_blank>Read here</a> - these are not enforceable rules, but guidelines for all players to follow.
+  </span>
 </p>
 {% endblock %}

--- a/templates/rules/x.html
+++ b/templates/rules/x.html
@@ -1,213 +1,211 @@
-{% extends 'base.html' %}
+{% extends 'rules/base.html' %}
 
-{% block content %}
-<div class=rules-text>
-  <p align=center>
-    <strong>
+{% block rules_content %}
+<p align=center>
+  <strong>
+    <span style=font-size:xx-large>
+      <span style=font-family:Arial>&nbsp; F-Zero Central F-ZERO X Time Submission Rules</span>
+    </span>
+  </strong>
+</p>
+<p>
+  <span style=font-family:Arial></span>
+</p>
+<p align=center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>
       <span style=font-size:xx-large>
-        <span style=font-family:Arial>&nbsp; F-Zero Central F-ZERO X Time Submission Rules</span>
-      </span>
-    </strong>
-  </p>
-  <p>
-    <span style=font-family:Arial></span>
-  </p>
-  <p align=center>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>
-        <span style=font-size:xx-large>
-          <span style=font-size:small>Last Updated: 11 April 2020</span>
-        </span>
+        <span style=font-size:small>Last Updated: 11 April 2020</span>
       </span>
     </span>
-  </p>
-  <hr>
-  <p style=text-align:center>&nbsp; <span style=font-family:Arial></span>
-    <span style=font-size:x-large>Rules for all F-Zero X Ladders</span>
-  </p>
-  <p>&nbsp; <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the FZX Ladder as they present the player with an unfair advantage. <strong>Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</strong>
-    </span>
-    <span style=font-family:Arial></span>
-  </p>
-  <p>
-    <span style=font-family:Arial>2. Players are reminded that FZC only accepts times set with the game cartridge, the Wii Virtual Console version and the Wii U Virtual Console version. There shall be no exceptions made for allowing people to submit times set using a ROM. Any times that are found to have been set using a ROM will be deleted. </span>
-  </p>
-  <p>
-    <span style=font-family:Arial></span>
-  </p>
-  <p>
-    <span style=font-family:Arial>3. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for team</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>4. The use of cheat devices such as Action Replay are forbidden on the ladder. If it is suspected that a cheat device has been used then that player will have their times removed from the ladder.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>5. Modifying and/or tinkering with the hardware to improve your times&nbsp;is prohibited. things like the Crooked Cartridge glitch (pulling the cart out a bit&nbsp;from the N64 while still playing) and altering the controllers with things such as Lego to make a turbo button&nbsp;are banned. if you have times set using these kind of modifications, they should be changed inmediately.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>6. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff.&nbsp;</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>7. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>8. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
+  </span>
+</p>
+<hr>
+<p style=text-align:center>&nbsp; <span style=font-family:Arial></span>
+  <span style=font-size:x-large>Rules for all F-Zero X Ladders</span>
+</p>
+<p>&nbsp; <span style=font-family:Arial>1. Turbo Controllers are banned from being used on the FZX Ladder as they present the player with an unfair advantage. <strong>Players are reminded that if they have any&nbsp;times set with a turbo controller they must change them&nbsp;immediately.</strong>
+  </span>
+  <span style=font-family:Arial></span>
+</p>
+<p>
+  <span style=font-family:Arial>2. Players are reminded that FZC only accepts times set with the game cartridge, the Wii Virtual Console version and the Wii U Virtual Console version. There shall be no exceptions made for allowing people to submit times set using a ROM. Any times that are found to have been set using a ROM will be deleted. </span>
+</p>
+<p>
+  <span style=font-family:Arial></span>
+</p>
+<p>
+  <span style=font-family:Arial>3. Submit times only achieved by yourself, don't submit times that have been achieved by a number of people. It is an individual competition it's not meant for team</span>
+</p>
+<p>
+  <span style=font-family:Arial>4. The use of cheat devices such as Action Replay are forbidden on the ladder. If it is suspected that a cheat device has been used then that player will have their times removed from the ladder.</span>
+</p>
+<p>
+  <span style=font-family:Arial>5. Modifying and/or tinkering with the hardware to improve your times&nbsp;is prohibited. things like the Crooked Cartridge glitch (pulling the cart out a bit&nbsp;from the N64 while still playing) and altering the controllers with things such as Lego to make a turbo button&nbsp;are banned. if you have times set using these kind of modifications, they should be changed inmediately.</span>
+</p>
+<p>
+  <span style=font-family:Arial>6. FZC reserves the right to request proof of your times. Proof could be requested at random or a concern that false times may have been submitted. Video proof is the preferred standard but understand that some people are unable to make videos, so photo proof of the records screen is accepted as well. Any requests for proof will be handled by a member of the F-Zero Staff.&nbsp;</span>
+</p>
+<p>
+  <span style=font-family:Arial>7. Multiple accounts for the same player are not allowed, neither are joint accounts.</span>
+</p>
+<p>
+  <span style=font-family:Arial>8. Finally, NO CHEATING of any kind will be tolerated and will result in immediate removal from the ladders and will also be considered for immediate removal in other F-Zero Ladders on FZC.</span>
+  <span style=font-family:Arial>
+    <br>
+  </span>
+</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-size:x-large>Save State Rules for Runs Submitted to Ladder <br>
+  </span>
+</p>
+<p style=text-align:center>For practice, save states may be used however a player likes. However when submitting runs to the FZC ladder or for WR, save states may only be used as described below. If save states are used anywhere else other than as described below, the player doing so will have their associated time removed.</p>
+<p>
+  <span style=font-size:large>3-Laps</span>
+</p>
+<p>Before the timer of the 3-lap attempt first starts.</p>
+<p>
+  <span style=font-size:large>Fast Laps</span>
+</p>
+<p>Before Boost Power and/or any advanced technique is performed that leads into the fast lap being attempted (example: the save state must be set before starting the AGG setup for a fast lap)</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>Normal X ladder and Death Race Ladder Rules</span>
+    <br>
+  </span>
+</p>
+<p>
+  <span style=font-family:Arial>1. Any engine settings may be used. <br>
+  </span>
+</p>
+<p>
+  <span style=font-family:Arial>2. You may only use the normal 30 vehicles.&nbsp; You may not use the Super Falcon, Super Stingray, Super Cat, or any custom vehicles.</span>
+</p>
+<p>
+  <span style=font-family:Arial>3. Any glitches/techniques may be used except for pulling the corner of the N64 cartridge.</span>
+</p>
+<p>
+  <span style=font-family:Arial>4. Only submit times that are shown on your records screen. <br>
+  </span>
+</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>Expansion Kit Ladder Rules</span>
+    <br>
+  </span>
+</p>
+<p>
+  <span style=font-family:Arial>1. All engine settings may be used.</span>
+</p>
+<p>
+  <span style=font-family:Arial>2. You may use any vehicle, including custom vehicles.</span>
+</p>
+<p>
+  <span style=font-family:Arial>3. Any glitches/techniques may be used except for pulling the corner of the N64 cartridge.</span>
+</p>
+<p>
+  <span style=font-family:Arial>4. Only submit times that are shown on your records screen.</span>
+</p>
+<div>&nbsp;</div>
+<p>
+  <em>
+    <span style=font-family:Arial>Flashcart Rules</span>
+  </em>
+</p>
+<p>
+  <span style=font-family:Arial>Due to how difficult it is to obtain a 64DD and Expansion Kit and how much flash carts have advanced in the last decade, it's been decided that times set using one of these will be allowed with certain conditions:</span>
+</p>
+<p>
+  <span style=font-family:Arial>1. You must use either an Everdrive 64 v2.5 or v3 or a 64Drive flash cart. these are the only ones tested by the community to work correctly with the FZX + EK combined rom.</span>
+</p>
+<p>
+  <span style=font-family:Arial>2. No cheat codes are allowed. the flash carts posses cheat code functionality but it should be avoided at any cost. patches aren't allowed either.</span>
+</p>
+<p>
+  <span style=font-family:Arial>3. Only the japanese FZX + EK rom is allowed. we want to ensure there's no difference between the game played on real hardware and played with the flash carts. using the unmodified combined rom is the closest to that. also, patching a normal FZX rom with EK tracks is not allowed since there's a couple of differences between the regular rom and the combined rom.</span>
+</p>
+<p>
+  <span style=font-family:Arial>4. When using a flash cart to set times, you must mention it in the comments section.</span>
+</p>
+<div>&nbsp;</div>
+<p>
+  <span style=font-family:Arial>Proof will be handled in the same fashion as in the rest of the games. that means you need video proof if you get a WR time or very close to it.</span>
+</p>
+<p>
+  <span style=font-family:Arial>Video proof is important given the possibilities of modification, which means times set with a flashcart will be under tighter scrutiny.</span>
+</p>
+<p>
+  <span style=font-family:Arial>as a special note, it's still not allowed to use a flash cart with the regular tracks in the regular ladder.</span>
+</p>
+<hr>
+<p style=text-align:center>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>Jumper Ladder Rules</span>
+    <br>
+  </span>
+</p>
+<p>
+  <span style=font-family:Arial>1. Only jumper engine settings may be used.&nbsp; This means that the engine setting on the pick-up graph has to be within four ticks of the right side of the graph.&nbsp; The area in red in the following diagram indicates the area allowed.</span>
+</p>
+<p>
+  <strong>I-i-i-i-i-i-i-I-i-i- <span style=color:rgb(255,0,0)>i-i-i-i-I</span>
+  </strong>
+</p>
+<p>
+  <span style=font-family:Arial>2. You may only use the normal 30 vehicles.&nbsp; You may not use the Super Falcon, Super Stingray, Super Cat, or any custom vehicles.</span>
+</p>
+<p>
+  <span style=font-family:Arial>3. Any glitches/techniques may be used except for pulling the corner of the N64 cartridge and the Air Ground Glitch.</span>
+</p>
+<p>
+  <span style=font-family:Arial>4. Only submit times that are shown on your records screen or on the results screen that is displayed at the end of a race. <br>
+  </span>
+</p>
+<hr>
+<p style=text-align:center>&nbsp; <span style=font-family:Arial></span>
+  <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
+</p>
+<p style=text-align:center>
+  <span style=font-family:Arial>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof. If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*.</span>
+</p>
+<p style=text-align:left>
+  <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
+</p>
+<ol>
+  <li>
+    <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
+  </li>
+  <li>
+    <span style=font-family:Arial>The video must display the ending stat</span>
+    <span style=font-family:Arial>s from the race after it is over.</span>
+  </li>
+  <li>
+    <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
+  </li>
+  <li>
     <span style=font-family:Arial>
-      <br>
+      <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any too see, FZC witholds the right to take down your time associated with that video.</span>
     </span>
-  </p>
-  <hr>
-  <p style=text-align:center>
-    <span style=font-size:x-large>Save State Rules for Runs Submitted to Ladder <br>
-    </span>
-  </p>
-  <p style=text-align:center>For practice, save states may be used however a player likes. However when submitting runs to the FZC ladder or for WR, save states may only be used as described below. If save states are used anywhere else other than as described below, the player doing so will have their associated time removed.</p>
-  <p>
-    <span style=font-size:large>3-Laps</span>
-  </p>
-  <p>Before the timer of the 3-lap attempt first starts.</p>
-  <p>
-    <span style=font-size:large>Fast Laps</span>
-  </p>
-  <p>Before Boost Power and/or any advanced technique is performed that leads into the fast lap being attempted (example: the save state must be set before starting the AGG setup for a fast lap)</p>
-  <hr>
-  <p style=text-align:center>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>Normal X ladder and Death Race Ladder Rules</span>
-      <br>
-    </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>1. Any engine settings may be used. <br>
-    </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>2. You may only use the normal 30 vehicles.&nbsp; You may not use the Super Falcon, Super Stingray, Super Cat, or any custom vehicles.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>3. Any glitches/techniques may be used except for pulling the corner of the N64 cartridge.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>4. Only submit times that are shown on your records screen. <br>
-    </span>
-  </p>
-  <hr>
-  <p style=text-align:center>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>Expansion Kit Ladder Rules</span>
-      <br>
-    </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>1. All engine settings may be used.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>2. You may use any vehicle, including custom vehicles.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>3. Any glitches/techniques may be used except for pulling the corner of the N64 cartridge.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>4. Only submit times that are shown on your records screen.</span>
-  </p>
-  <div>&nbsp;</div>
-  <p>
-    <em>
-      <span style=font-family:Arial>Flashcart Rules</span>
-    </em>
-  </p>
-  <p>
-    <span style=font-family:Arial>Due to how difficult it is to obtain a 64DD and Expansion Kit and how much flash carts have advanced in the last decade, it's been decided that times set using one of these will be allowed with certain conditions:</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>1. You must use either an Everdrive 64 v2.5 or v3 or a 64Drive flash cart. these are the only ones tested by the community to work correctly with the FZX + EK combined rom.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>2. No cheat codes are allowed. the flash carts posses cheat code functionality but it should be avoided at any cost. patches aren't allowed either.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>3. Only the japanese FZX + EK rom is allowed. we want to ensure there's no difference between the game played on real hardware and played with the flash carts. using the unmodified combined rom is the closest to that. also, patching a normal FZX rom with EK tracks is not allowed since there's a couple of differences between the regular rom and the combined rom.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>4. When using a flash cart to set times, you must mention it in the comments section.</span>
-  </p>
-  <div>&nbsp;</div>
-  <p>
-    <span style=font-family:Arial>Proof will be handled in the same fashion as in the rest of the games. that means you need video proof if you get a WR time or very close to it.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>Video proof is important given the possibilities of modification, which means times set with a flashcart will be under tighter scrutiny.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>as a special note, it's still not allowed to use a flash cart with the regular tracks in the regular ladder.</span>
-  </p>
-  <hr>
-  <p style=text-align:center>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>Jumper Ladder Rules</span>
-      <br>
-    </span>
-  </p>
-  <p>
-    <span style=font-family:Arial>1. Only jumper engine settings may be used.&nbsp; This means that the engine setting on the pick-up graph has to be within four ticks of the right side of the graph.&nbsp; The area in red in the following diagram indicates the area allowed.</span>
-  </p>
-  <p>
-    <strong>I-i-i-i-i-i-i-I-i-i- <span style=color:rgb(255,0,0)>i-i-i-i-I</span>
-    </strong>
-  </p>
-  <p>
-    <span style=font-family:Arial>2. You may only use the normal 30 vehicles.&nbsp; You may not use the Super Falcon, Super Stingray, Super Cat, or any custom vehicles.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>3. Any glitches/techniques may be used except for pulling the corner of the N64 cartridge and the Air Ground Glitch.</span>
-  </p>
-  <p>
-    <span style=font-family:Arial>4. Only submit times that are shown on your records screen or on the results screen that is displayed at the end of a race. <br>
-    </span>
-  </p>
-  <hr>
-  <p style=text-align:center>&nbsp; <span style=font-family:Arial></span>
-    <span style=font-size:x-large>FZC Best and World Record Submission Rules</span>
-  </p>
-  <p style=text-align:center>
-    <span style=font-family:Arial>To have a FZC Best or World Record accepted to FZC, it must follow the requirements of full video proof. If a FZC Best/WR does not adhere to the requirements listed for full video proof, the time is subject to immediate removal from the ladder*.</span>
-  </p>
-  <p style=text-align:left>
-    <span style=font-family:Arial>Requirements of 'Full Video Proof:'</span>
-  </p>
-  <ol>
-    <li>
-      <span style=font-family:Arial>The video must be a <strong>full</strong> recording of the actual run from start of the race to finish. </span>
-    </li>
-    <li>
-      <span style=font-family:Arial>The video must display the ending stat</span>
-      <span style=font-family:Arial>s from the race after it is over.</span>
-    </li>
-    <li>
-      <span style=font-family:Arial>If the video is being recorded from a camera and not directly from the source, the player must bring the controller up to the camera at the end of the race and push buttons on the game pad to indicate that what is happening on display is in sync with the players input.</span>
-    </li>
-    <li>
-      <span style=font-family:Arial>
-        <span style=color:rgb(0,0,0)>The video must always be available to the public. If at any point you remove your video for any too see, FZC witholds the right to take down your time associated with that video.</span>
-      </span>
-    </li>
-  </ol>
-  <p>
-    <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
-  </p>
-  <hr>
-  <p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
-    <span style=font-family:Arial>
-      <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
-    </span>
-  </p>
-  <p style=background-color:rgb(247,247,247)>
-    <font face=Arial>
-      <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
-    </font>
-    <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
-      <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
-    </a>
-  </p>
-</div>
+  </li>
+</ol>
+<p>
+  <span style=font-family:Arial>*FZC Bests/World Records submitted to FZC previous to the date of March 1st 2013 do not need to adhere by the requirements of 'Full Video Proof.'</span>
+</p>
+<hr>
+<p style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background-color:rgb(247,247,247);text-align:center'>
+  <span style=font-family:Arial>
+    <span style=font-size:x-large>F-Zero Central Ladder Guidelines</span>
+  </span>
+</p>
+<p style=background-color:rgb(247,247,247)>
+  <font face=Arial>
+    <span style=font-size:13.3333px>The following are not enforceable&nbsp;rules, but guidelines for all players to follow:&nbsp;</span>
+  </font>
+  <a href="https://www.fzerocentral.org/viewtopic.php?t=14230" style='font-family:verdana,"courier new",Arial,Helvetica,sans-serif;font-size:13.3333px;background:transparent;color:rgb(61,106,147)'>
+    <span style=font-family:Arial>www.fzerocentral.org/viewtopic.php</span>
+  </a>
+</p>
 {% endblock %}

--- a/templates/rules/x.html
+++ b/templates/rules/x.html
@@ -151,8 +151,7 @@
   <span style=font-family:Arial>1. Only jumper engine settings may be used.&nbsp; This means that the engine setting on the pick-up graph has to be within four ticks of the right side of the graph.&nbsp; The area in red in the following diagram indicates the area allowed.</span>
 </p>
 <p>
-  <strong>I-i-i-i-i-i-i-I-i-i- <span style=color:rgb(255,0,0)>i-i-i-i-I</span>
-  </strong>
+  <strong>I-i-i-i-i-i-i-I-i-i-<span style=color:rgb(255,0,0)>i-i-i-i-I</span></strong>
 </p>
 <p>
   <span style=font-family:Arial>2. You may only use the normal 30 vehicles.&nbsp; You may not use the Super Falcon, Super Stingray, Super Cat, or any custom vehicles.</span>


### PR DESCRIPTION
- Rules and guidelines contents were taken from these snapshots of the previous FZC site, 2021/04: https://drive.google.com/drive/folders/1P-o-ZD1Tz0XDek-di9-nulLYXUYCYUFX

- Only made a few minor formatting edits on top of that, and also slightly re-wording the rules' links to the guidelines.

- Updated text at the top of time submissions pages (unique per ladder) to:

  - Link to the new rules pages instead of the old forum posts.
  - Have consistent wording for the rules links; a few of the newer ladders worded it differently.
  - Use HTML escape codes on ladders 16 and 18 so that the text actually gets parsed properly and shows up on the page.

Potential future steps: link the rules pages from somewhere other than submission pages, clean up HTML markup on rules/guidelines pages, consolidate some rules to be more clear/concise.

Technical notes: I added a `data/games` dir (alongside the existing `data/ladders`) for defining per-game attributes. I saw that some steps had been taken to migrate from XML to YAML, but since we didn't seem to have an example of reading from YAML yet, I stuck with XML for now.