### PR TITLE
Add link to rules from ladder.php

### DIFF
--- a/templates/ladder.html
+++ b/templates/ladder.html
@@ -23,8 +23,11 @@
       </div>
     </details>
 
-    <p><a href="/client.php?ladder={{ ladder_id }}">Add your times</a></p>
-    <p><a href="/ladder_latest.php?id={{ ladder_id }}">Latest submissions</a></p>
+    <p>
+      <a href="/rules.php?game={{ selected_game }}">Rules</a>
+      | <a href="/client.php?ladder={{ ladder_id }}">Add your times</a>
+      | <a href="/ladder_latest.php?id={{ ladder_id }}">Latest submissions</a>
+    </p>
   </div>
 
   <table class='scoreboard'>


### PR DESCRIPTION
Addresses this bit from PR #13:

> Potential future steps: link the rules pages from somewhere other than submission pages ...

In particular, this allows non-members (who cannot access submission pages) to view the rules.