### PR TITLE
Record display fixes

### DIFF
--- a/common.php
+++ b/common.php
@@ -28,13 +28,19 @@ class Project_Twig_Extension extends \Twig\Extension\AbstractExtension {
       }, ['is_safe' => ['html']]),
       new \Twig\TwigFilter('proof_link', function($record, $prefix = '') {
         if ($record["${prefix}verified"]) {
-          $url = "/images/proof_statuses/verified-proof.png";
+          $icon_url = "/images/proof_statuses/verified-proof.png";
         } else {
-          $url = "/images/proof_statuses/unverified-proof.png";
+          $icon_url = "/images/proof_statuses/unverified-proof.png";
         }
 
-        $proof = htmlspecialchars($record["${prefix}videourl"]);
-        return "<a href='$proof'><img src='$url' /></a>";
+        $proof_url = $record["${prefix}videourl"];
+        if (!isset(parse_url($proof_url)["scheme"])) {
+          // Proof URLs are generally external links. Don't let scheme-less
+          // URLs be interpreted as relative internal links.
+          $proof_url = "https://{$proof_url}";
+        }
+        $proof_url = htmlspecialchars($proof_url);
+        return "<a href='$proof_url'><img src='$icon_url' /></a>";
       }, ['is_safe' => ['html']]),
     ];
   }

--- a/common.php
+++ b/common.php
@@ -20,7 +20,9 @@ if (isset($_SESSION['current_user_id'])) {
 class Project_Twig_Extension extends \Twig\Extension\AbstractExtension {
   public function getFilters() {
     return [
-      new \Twig\TwigFilter('format_time', function($v) { return format_time($v, ''); }),
+      new \Twig\TwigFilter('format_time', function($value, $time_format = '') {
+         return format_time($value, $time_format);
+      }),
       new \Twig\TwigFilter('flag', function($country) {
         $country = htmlspecialchars($country);
         $flag = $country == '' ? 'undefined' : strtolower($country);

--- a/common.php
+++ b/common.php
@@ -23,6 +23,9 @@ class Project_Twig_Extension extends \Twig\Extension\AbstractExtension {
       new \Twig\TwigFilter('format_time', function($value, $time_format = '') {
          return format_time($value, $time_format);
       }),
+      new \Twig\TwigFilter('format_time_part', function($value, $part_name, $time_format = '') {
+         return format_time_part($value, $part_name, $time_format);
+      }),
       new \Twig\TwigFilter('flag', function($country) {
         $country = htmlspecialchars($country);
         $flag = $country == '' ? 'undefined' : strtolower($country);

--- a/public/game.php
+++ b/public/game.php
@@ -92,7 +92,12 @@ foreach ($ladders as $ladder) {
         AND phpbb_f0_totals.user_id = $current_user_id
     ");
     $row = mysqli_fetch_assoc($result);
-    $my_times[$ladder] = ['time' => format_time($row['time'], ''), 'lap' => format_time($row['lap'], '')];
+
+    $ladder_timeformat = FserverLadder($ladder)->timeformat;
+    $my_times[$ladder] = [
+      'time' => format_time($row['time'], $ladder_timeformat),
+      'lap' => format_time($row['lap'], $ladder_timeformat),
+    ];
   }
 
   $active_players[$ladder] = FserverGetActivePlayers($ladder);

--- a/public/player.php
+++ b/public/player.php
@@ -81,7 +81,8 @@ $result = db_query("
 
 $total_c = [];
 while ($row = mysqli_fetch_assoc($result)) {
-  $total_c[$row['ladder_id']] = format_time($row['time'], '');
+  $ladder = FserverLadder($row['ladder_id']);
+  $total_c[$row['ladder_id']] = format_time($row['time'], $ladder->timeformat);
 }
 
 // Lap Totals
@@ -93,7 +94,8 @@ $result = db_query("
 
 $total_l = [];
 while ($row = mysqli_fetch_assoc($result)) {
-  $total_l[$row['ladder_id']] = format_time($row['lap'], '');
+  $ladder = FserverLadder($row['ladder_id']);
+  $total_l[$row['ladder_id']] = format_time($row['lap'], $ladder->timeformat);
 }
 
 // Course Ranks

--- a/src/fzero.php
+++ b/src/fzero.php
@@ -20,6 +20,29 @@ function format_time($time, $timeformat) {
   return sprintf("%d'%02d\"%03d", $minutes, $seconds, $thousands);
 }
 
+function format_time_part($value, $part_name, $timeformat) {
+  if ($value == '') {
+    // Missing times should have their fields blank
+    return '';
+  }
+
+  if ($part_name == 'Seconds') {
+    // 1'02"345, not 1'2"345
+    return sprintf("%02d", $value);
+  }
+  if ($part_name == 'Subseconds') {
+    if ($timeformat == 'Hundredths') {
+      // 1'23"04, not 1'23"4
+      return sprintf("%02d", $value);
+    }
+    else {
+      // 1'23"045, not 1'23"45
+      return sprintf("%03d", $value);
+    }
+  }
+  return $value;
+}
+
 function ladder_game($ladder_id) {
   return [
     1 => 'snes',

--- a/templates/course.html
+++ b/templates/course.html
@@ -51,7 +51,7 @@
             <a href='viewplayer.php?ladder={{ ladder_id }}&user={{ entry.user_id }}'>{{ entry.username|e }}</a>
           </td>
           <td>
-            <span>{{ entry.course_value | format_time }}</span>
+            <span>{{ entry.course_value|format_time(ladder.timeformat) }}</span>
             <img src="{{ entry.course_ship_image|e }}" title="{{ entry.course_ship }}" />
             {% if entry.course_has_proof %}
               {{ entry | proof_link("course_") }}
@@ -60,7 +60,7 @@
           </td>
           <td>
             {% if ladder.haslap == 'Yes' %}
-              <span>{{ entry.lap_value|format_time }}</span>
+              <span>{{ entry.lap_value|format_time(ladder.timeformat) }}</span>
               <img src="{{ entry.lap_ship_image|e }}" title="{{ entry.lap_ship }}" />
               {% if entry.lap_has_proof %}
                 {{ entry | proof_link("lap_") }}

--- a/templates/ladder.html
+++ b/templates/ladder.html
@@ -54,8 +54,8 @@
           <td>{{ entry.last_change }}</td>
           <td>{{ entry.af }}</td>
           <td>{{ entry.srpr }}</td>
-          <td>{{ entry.time|format_time }}</td>
-          <td>{{ entry.lap|format_time }}</td>
+          <td>{{ entry.time|format_time(ladder.timeformat) }}</td>
+          <td>{{ entry.lap|format_time(ladder.timeformat) }}</td>
         </tr>
       {% endfor %}
     </tbody>

--- a/templates/ladder_latest.html
+++ b/templates/ladder_latest.html
@@ -48,7 +48,7 @@
             {% if entry.record_type == 'S' %}
               {{ entry.value }}
             {% else %}
-              {{ entry.value|format_time }}
+              {{ entry.value|format_time(ladder.timeformat) }}
             {% endif %}
           </td>
           <td>{{ 1 }}</td>

--- a/templates/submission-entry.html
+++ b/templates/submission-entry.html
@@ -12,8 +12,10 @@
   <div class="value-fields">
     {% if sub_type != "S" %}
       <input name='records[{{ field_prefix }}][time@m]' type='text' maxlength='1' size='1' value='{{ sub.time_m }}' />
-      <input name='records[{{ field_prefix }}][time@s]' type='text' maxlength='2' size='2' value='{{ sub.time_s }}' />
-      <input name='records[{{ field_prefix }}][time@t]' type='text' maxlength='4' size='4' value='{{ sub.time_t }}' />
+
+      <input name='records[{{ field_prefix }}][time@s]' type='text' maxlength='2' size='2' value='{{ sub.time_s|format_time_part("Seconds") }}' />
+
+      <input name='records[{{ field_prefix }}][time@t]' type='text' maxlength='4' size='4' value='{{ sub.time_t|format_time_part("Subseconds", ladder.timeformat) }}' />
     {% else %}
       <input name='records[{{ field_prefix }}][speed]' type='text' maxlength='6' size='6' value='{{ sub.speed }}' />
     {% endif %}

--- a/templates/viewplayer.html
+++ b/templates/viewplayer.html
@@ -27,7 +27,7 @@
             <a href='course.php?ladder={{ ladder_id }}&cup={{ cup.attributes.cupid }}&course={{ course.attributes.courseid }}'>{{ course.name|e }}</a>
           </td>
           <td>
-            <span>{{ record.C.value | format_time }}</span>
+            <span>{{ record.C.value|format_time(ladder.timeformat) }}</span>
             <img src="{{ record.C.ship_image|e }}" title="{{ record.C.ship }}" />
             {% if record.C.has_proof %}
               {{ record.C | proof_link }}
@@ -35,7 +35,7 @@
           </td>
           <td>
             {% if ladder.haslap == 'Yes' %}
-              <span>{{ record.L.value|format_time }}</span>
+              <span>{{ record.L.value|format_time(ladder.timeformat) }}</span>
               <img src="{{ record.L.ship_image|e }}" title="{{ record.L.ship }}" />
               {% if record.L.has_proof %}
                 {{ record.L | proof_link }}
@@ -65,16 +65,16 @@
     <tr>
       <td>{{ cup.cupname|e }} totals</td>
       <td>
-        <span>{{ totals[cup.attributes.cupid.__toString].C|format_time }}</span>
+        <span>{{ totals[cup.attributes.cupid.__toString].C|format_time(ladder.timeformat) }}</span>
       </td>
       <td>
         {% if ladder.haslap == 'Yes' %}
-          <span>{{ totals[cup.attributes.cupid.__toString].L|format_time }}</span>
+          <span>{{ totals[cup.attributes.cupid.__toString].L|format_time(ladder.timeformat) }}</span>
         {% endif %}
       </td>
       {% if ladder.hasspeed == 'Yes' %}
         <td>
-          <span>{{ totals[cup.attributes.cupid.__toString].S|format_time }}</span>
+          <span>{{ totals[cup.attributes.cupid.__toString].S }}</span>
         </td>
       {% endif %}
       <td></td>
@@ -99,16 +99,16 @@
     <tr>
       <td>{{ ladder.ladder_name|e }} totals</td>
       <td>
-        {{ totals[0].C | format_time }}
+        {{ totals[0].C | format_time(ladder.timeformat) }}
       </td>
       <td>
         {% if ladder.haslap == 'Yes' %}
-          {{ totals[0].L | format_time }}
+          {{ totals[0].L | format_time(ladder.timeformat) }}
         {% endif %}
       </td>
       {% if ladder.hasspeed == 'Yes' %}
         <td>
-          {{ totals[0].S | format_time }}
+          {{ totals[0].S }}
         </td>
       {% endif %}
       <td></td>


### PR DESCRIPTION
- Add schemes to scheme-less proof URLs before adding them to anchor elements, so that they're not interpreted as relative URLs, leading to stuff like `https://fzerocentral.org/youtube.com/watch?...`
- Display times with hundredths or thousandths depending on the ladder (was always thousandths in most places).
- On the times submission page, show appropriate leading zeros for existing times.