### PR TITLE
Front page updates + 'See also' links for games

### DIFF
--- a/data/games/gx.xml
+++ b/data/games/gx.xml
@@ -2,4 +2,14 @@
 <game>
   <name>F-Zero GX</name>
   <rules_template>rules/gx.html</rules_template>
+  <home_see_also>
+    <link>
+      <display>Combined leaderboard</display>
+      <url>https://docs.google.com/spreadsheets/d/10mZeQrMLaaPMdC0ZeKR2Wk1XtzICG2n4XTw9yyx-dKw/edit#gid=488310816</url>
+    </link>
+    <link>
+      <display>Per-machine records (Max speed)</display>
+      <url>https://docs.google.com/spreadsheets/d/17DqpOEgzh0RqSKZ-5q5kanhI3uRhQ6w0xo4GTJO5cQI/edit</url>
+    </link>
+  </home_see_also>
 </game>

--- a/public/fzero.css
+++ b/public/fzero.css
@@ -116,8 +116,7 @@ th.thTop	 { border-width: 1px 0px 0px 0px; text-align : center;}
 th.thCornerL { border-width: 0px 0px 0px 0px;  text-align : center;}
 th.thCornerR { border-width: 1px 1px 0px 0px;  text-align : center;  }
 
-/* The largest text used in the index page title and toptic title etc. */
-.maintitle,h1,h2	{	font-weight: bold; 	font-size: 22px; 	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;	text-decoration: none; 	line-height : 120%; 	color : #CCCCCC;}
+h1,h2	{	font-weight: bold; 	font-size: 22px; 	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;	text-decoration: none; 	line-height: 120%; 	color: black;}
 
 
 /* General text */

--- a/public/fzero.css
+++ b/public/fzero.css
@@ -1007,6 +1007,14 @@ div.ladder-leaders > div > div > span {
   padding: 10px;
 }
 
+.see-also {
+  background-color: #ebf4fe;
+  font-family: Verdana;
+  padding: 10px;
+  margin-bottom: 20px;
+  border-radius: 10px;
+}
+
 .page-player-ladder .main-content {
   max-width: 960px;
   margin: 0px auto;

--- a/public/game.php
+++ b/public/game.php
@@ -2,9 +2,10 @@
 
 require_once '../common.php';
 
-$game = $_GET['id'];
+$game_shortcode = $_GET['id'];
+$game = FserverGame($game_shortcode);
 
-switch ($game) {
+switch ($game_shortcode) {
 case 'gx':
   $ladders = [4, 5, 8, 11, 12];
   break;
@@ -106,12 +107,13 @@ foreach ($ladders as $ladder) {
 $template = $twig->load('game.html');
 echo render_template($template, [
   'page_class' => 'page-game',
-  'PAGE_TITLE' => "$game Home",
+  'PAGE_TITLE' => "$game->name Home",
   'ladders' => $ladders,
   'leaderboard' => $leaderboard,
   'ladder_types' => $ladder_types,
   'my_times' => $my_times,
   'active_players' => $active_players,
-  'selected_game' => $game,
+  'selected_game' => $game_shortcode,
   'current_user' => $current_user,
+  'see_also' => $game->home_see_also,
 ]);

--- a/templates/client.html
+++ b/templates/client.html
@@ -105,7 +105,7 @@
 <!-- This outer container only serves to make main-container a flex item. -->
 <div class="main-container-container">
   <div class="main-container">
-    <h2 style="color:#000000;">
+    <h2>
       {{ current_user.username }}'s times in the F-Zero {{ ladder.ladder_name }} Ladder
     </h2>
 

--- a/templates/game.html
+++ b/templates/game.html
@@ -96,4 +96,18 @@
       </div>
     </div>
   {% endfor %}
+
+  {% if see_also %}
+    <div class='see-also'>
+      <h2>See also</h2>
+      <ul>
+        {% for link in see_also.link %}
+          <li>
+            <a href="{{ link.url }}">{{ link.display }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,9 +50,9 @@
               <img src="/images/welcome_banner.png" />
             </div>
             <div class="home-page-box-body">
-              Welcome to F-Zero Central! We are a competition and fan community for the high-speed, futuristic racing game series known as F-Zero. Our site features Time Attack ladders for each of the 6 F-Zero games released on console.
+              Welcome to F-Zero Central! We are a competition and fan community for the high-speed, futuristic racing game series known as F-Zero. Our site features Time Attack ladders for each of the 6 F-Zero games released on console. We are proud to represent F-Zero pilots of all skill levels here, from world record holders to those completely new to the series.
               <br><br>
-              We are proud to represent F-Zero pilots of all skill levels here, from world record holders to those completely new to the series. You can find discussion about the website on <a href="https://discord.gg/hEBSk55Cc9">our Discord server</a>. You can also find a lot of our members at the <a href="https://discord.gg/79pPFR2hHu">F-Zero Nexus Discord server</a>, which welcomes competitive discussion as well as general chat about F-Zero.
+              If you've got questions about our website or are interested in recent developments, we invite you to join the <a href="https://discord.gg/hEBSk55Cc9">FZC Discord server</a>. We also recommend checking out the <a href="https://discord.gg/79pPFR2hHu">F-Zero Nexus Discord server</a>, a broader F-Zero community which welcomes time attack related discussion as well as general chat about the series.
               <br><br>
               F-Zero Central is one of the oldest speedrun or time attack communities on the Internet, with over 15 years of history. Recently we've been short-handed in terms of site development, so some site features may be lacking for a while, but we'll do our best to keep things running. If you need any assistance with the site, feel free to ask us on our Discord, <a href="https://www.facebook.com/fzerocentral/">Facebook</a>, or <a href="https://twitter.com/fzerocentral">Twitter</a>.
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,10 +25,10 @@
               <span>Competition related links</span>
             </div>
             <div class="home-page-box-body links">
+              <a href="https://drive.google.com/drive/u/0/folders/1WRthnmQYcbz2Vgk_G7CYL2bcWStFh7rn">FZC Ladder Progression spreadsheets</a><br>
+              <a href="http://fzerowrs.com/">Fzerowrs: WR histories and stats</a><br>
               <a href="https://www.speedrun.com/f-zero">Speedrun.com RTA rankings</a><br>
-              <a href="http://fzerowrs.com/">WR histories and stats</a><br>
-              <a href="http://kabedori.blog33.fc2.com/">RichardTaro's WR blog (JP)</a><br>
-              <a href="https://www.cyberscore.me.uk/scoreboard.php?board=1&series=18">Cyberscore rankings</a>
+              <a href="https://cyberscore.me.uk/scoreboards/starboard?series=18">Cyberscore rankings</a>
             </div>
           </div>
           <div class="home-page-box">
@@ -36,8 +36,8 @@
               <span>Other F-Zero links</span>
             </div>
             <div class="home-page-box-body links">
-              <a href="https://discord.gg/79pPFR2hHu">Discord - F-Zero Nexus</a><br>
-              <a href="https://www.reddit.com/r/Fzero/">Reddit - /r/Fzero</a><br>
+              <a href="https://discord.gg/79pPFR2hHu">F-Zero Nexus Discord server</a><br>
+              <a href="https://www.reddit.com/r/Fzero/">/r/Fzero Subreddit</a><br>
               <a href="https://gamebanana.com/games/5899">GX mods at GameBanana</a><br>
               <a href="http://backup.segakore.fr/f-zero.jp/">GX/AX official site (archived)</a>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 
 {% block content %}
       <div id="home-page-column-container">
-        <div style="flex: 1 0 230px;">
+        <div style="flex: 1 0 240px;">
           <div class="home-page-box">
             <div class="home-page-box-header-bar">
               <span>News</span>
@@ -25,8 +25,8 @@
               <span>Competition related links</span>
             </div>
             <div class="home-page-box-body links">
-              <a href="https://drive.google.com/drive/u/0/folders/1WRthnmQYcbz2Vgk_G7CYL2bcWStFh7rn">FZC Ladder Progression spreadsheets</a><br>
-              <a href="http://fzerowrs.com/">Fzerowrs: WR histories and stats</a><br>
+              <a href="https://drive.google.com/drive/u/0/folders/1WRthnmQYcbz2Vgk_G7CYL2bcWStFh7rn">FZC Ladder Progression sheets</a><br>
+              <a href="http://fzerowrs.com/">Fzerowrs: WR histories/stats</a><br>
               <a href="https://www.speedrun.com/f-zero">Speedrun.com RTA rankings</a><br>
               <a href="https://cyberscore.me.uk/scoreboards/starboard?series=18">Cyberscore rankings</a>
             </div>

--- a/templates/player.html
+++ b/templates/player.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div style="font: 10pt Verdana; background-color: #f7f7f7; padding: 10px 20px; margin-bottom: 20px; border: 1px black solid; border-radius: 10px">
-  <h2 style="font-weight: bold; text-align: center; color: black">
+  <h2 style="text-align: center">
     {{ username|e }}'s F-Zero Summary
   </h2>
 </div>


### PR DESCRIPTION
- Update front page left column links.
- Update front page welcome message to clarify Discord servers' purposes.
- Support 'See also' links section at the bottom of each game's homepage (below the ladders list). Only GX has these specified for now, but we have the ability to add them for any game.