### PR TITLE
Fix speed submissions

### DIFF
--- a/src/fzero.php
+++ b/src/fzero.php
@@ -109,7 +109,7 @@ function user_to_ntsc_speed($ladder, $user, $value) {
   if (user_prefers_pal($user)) {
     $value = round($value * ladder_pal_ratio($ladder));
   }
-  return $time;
+  return $value;
 }
 
 function ship_image_url($ship_name) {


### PR DESCRIPTION
Top speed submissions seemed to be broken for any game that supported them (X and GX). That is, when you edited a speed and submitted, it wouldn't save. I think this should fix it, just correcting one variable name.