### PR TITLE
Overall ladder GX fix

### DIFF
--- a/src/fzero/recalc.php
+++ b/src/fzero/recalc.php
@@ -141,6 +141,12 @@ function recalc_af($ladder_id) {
     db_insert('phpbb_f0_champs_10', array_merge($entry, ['rank' => $rank]));
     $rank++;
   }
+
+  if (in_array($ladder_id, [4, 5, 8])) {
+    // After recalc of one of the individual GX ladders, recalc the overall GX
+    // pseudo-ladder
+    recalc_af_9();
+  }
 }
 
 function recalc_af_user($fzaf, $number_players, $player_records, $values) {
@@ -264,7 +270,7 @@ $ladder_srpr_weights = [
 
 function recalc_srpr($ladder_id) {
   if ($ladder_id == 9) {
-    recalc_af_9();
+    recalc_srpr_9();
     return;
   }
 
@@ -323,6 +329,12 @@ function recalc_srpr($ladder_id) {
   foreach ($entries as $entry) {
     db_insert('phpbb_f0_champs_10', array_merge($entry, ['rank' => $rank]));
     $rank++;
+  }
+
+  if (in_array($ladder_id, [4, 5, 8])) {
+    // After recalc of one of the individual GX ladders, recalc the overall GX
+    // pseudo-ladder
+    recalc_srpr_9();
   }
 }
 

--- a/templates/overall_ladder.html
+++ b/templates/overall_ladder.html
@@ -16,8 +16,8 @@
   </p>
 
   <p>
-    For information on how this ladder works, please read our
-    <a href="/forum/viewtopic.php?p=75346#75346">2010 F-Zero Time Attack Championship FAQ</a>.
+    For information on how this ladder works, please read the
+    <a href="https://fzerocentral.org/next/old-forum/view-topic?t=10551">2010 F-Zero Time Attack Championship FAQ</a>.
   </p>
 
   <p>


### PR DESCRIPTION
The GX portion of the Overall Ladder seems like it hasn't updated in a while. I'm pretty sure I found a bug which meant that the 'best GX' pseudo-ladder (ladder ID 9) wasn't ever getting recalculated. I changed it to recalc 9 whenever one of the main GX ladders (4, 5, or 8) gets updated.

Also refreshed the FAQ link at the top of the Overall Ladder page (to link to the forum archive).