### PR TITLE
Move yellow notice bar's contents from codebase to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You must create a `config.ini` file at the root of the repo and define certain v
 base_url = http://127.0.0.1:8000
 hmac_key = "around50randomlettersnumbersandsymbols^+_(&@-!*)"
 debug = true
+notice_bar_message = "This message appears on a bar above the social media buttons. If this variable is omitted entirely, the bar won't show."
 
 [database]
 host = localhost

--- a/common.php
+++ b/common.php
@@ -58,7 +58,16 @@ $twig->AddExtension(new Project_Twig_Extension());
 
 
 function render_template($template, $args) {
+  global $config;
+
+  // The notice bar message, if specified, appears on a bar above the social
+  // media buttons bar. It's specified in config.
+  if (array_key_exists('notice_bar_message', $config['app'])) {
+    $args['notice_bar_message'] = $config['app']['notice_bar_message'];
+  }
+
   $args['fzero_css_mtime'] = filemtime('fzero.css');
+
   return $template->render($args);
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -136,11 +136,13 @@
       </div>
     </div>
 
-    <div style='color: black; background-color: #F8DE7E; padding: 10px; font-size: 10pt'>
-      <p style='margin: 0px;'>
-        Registration is available again as of December 2023!
-      </p>
-    </div>
+    {% if notice_bar_message %}
+      <div style='color: black; background-color: #F8DE7E; padding: 10px; font-size: 10pt'>
+        <p style='margin: 0px;'>
+          {{ notice_bar_message }}
+        </p>
+      </div>
+    {% endif %}
 
     <!-- Bar for social media icons + game specific buttons -->
     <div id="button-bar">


### PR DESCRIPTION
This makes it easier to add 'soft maintenance' messages there, such as email-related functionality being on and off as it's being worked on.