### PR TITLE
Include current_user in profile.php's template context

### DIFF
--- a/common.php
+++ b/common.php
@@ -58,7 +58,9 @@ $twig->AddExtension(new Project_Twig_Extension());
 
 
 function render_template($template, $args) {
-  global $config;
+  global $config, $current_user;
+
+  $args['current_user'] = $current_user;
 
   // The notice bar message, if specified, appears on a bar above the social
   // media buttons bar. It's specified in config.

--- a/public/championships_ladder.php
+++ b/public/championships_ladder.php
@@ -31,6 +31,5 @@ echo render_template($template, [
   'page_class' => 'page-championships-ladder',
   'PAGE_TITLE' => 'Championships Ladder',
   'leaderboard' => $leaderboard,
-  'current_user' => $current_user,
   'ladders' => $ladders,
 ]);

--- a/public/client.php
+++ b/public/client.php
@@ -149,7 +149,6 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
   echo render_template($template, [
     'page_class' => 'page-client',
     'PAGE_TITLE' => $current_user['username'] . "'s F-Zero " . $ladder->ladder_name . " Times",
-    'current_user' => $current_user,
     'ladder' => $ladder,
     'hasspeed' => $ladder->hasspeed == "Yes",
     'haslap' => $ladder->haslap == "Yes",

--- a/public/course.php
+++ b/public/course.php
@@ -106,5 +106,4 @@ echo render_template($template, [
   'course_id' => $course_id,
   'entries' => $entries,
   'totals' => $totals,
-  'current_user' => $current_user,
 ]);

--- a/public/game.php
+++ b/public/game.php
@@ -114,6 +114,5 @@ echo render_template($template, [
   'my_times' => $my_times,
   'active_players' => $active_players,
   'selected_game' => $game_shortcode,
-  'current_user' => $current_user,
   'see_also' => $game->home_see_also,
 ]);

--- a/public/index.php
+++ b/public/index.php
@@ -5,5 +5,4 @@ require_once '../common.php';
 $template = $twig->load('index.html');
 echo render_template($template, [
   'PAGE_TITLE' => 'Home',
-  'current_user' => $current_user,
 ]);

--- a/public/ladder.php
+++ b/public/ladder.php
@@ -59,6 +59,5 @@ echo render_template($template, [
   'entries' => $entries,
   'ladder' => $ladder,
   'ladder_id' => $ladder_id,
-  'current_user' => $current_user,
   'selected_game' => ladder_game($ladder_id),
 ]);

--- a/public/ladder_latest.php
+++ b/public/ladder_latest.php
@@ -40,7 +40,5 @@ echo render_template($template, [
   'entries' => $entries,
   'ladder' => $ladder,
   'ladder_id' => $ladder_id,
-  'current_user' => $current_user,
   'selected_game' => ladder_game($ladder_id),
 ]);
-

--- a/public/overall_ladder.php
+++ b/public/overall_ladder.php
@@ -133,6 +133,5 @@ echo render_template($template, [
     'overall_gpl'   => "overall_ladder.php?g=6&key=${key}",
     'overall_clmx'  => "overall_ladder.php?g=7&key=${key}",
   ],
-  'current_user' => $current_user,
 ]);
 ?>

--- a/public/player.php
+++ b/public/player.php
@@ -185,5 +185,4 @@ echo render_template($template, [
       7 => 'CLMX',
     ],
   ],
-  'current_user' => $current_user,
 ]);

--- a/public/viewplayer.php
+++ b/public/viewplayer.php
@@ -51,5 +51,4 @@ echo render_template($template, [
   'ladder_id' => $ladder_id,
   'entries' => $entries,
   'totals' => $totals,
-  'current_user' => $current_user,
 ]);


### PR DESCRIPTION
And ensure this isn't so easily forgotten in the future, by always including `current_user` in `render_template()`, instead of asking every individual caller of `render_template()` to include it.

When I previously added the profile.php page, the Login and Register links would show even when you were logged in (in fact, you have to be logged in to view that page). This happened because I forgot to include current_user in the template context.