### PR TITLE
Ability to change email address and username

### DIFF
--- a/account_utils.php
+++ b/account_utils.php
@@ -64,10 +64,12 @@ function get_user_by_field($field_name, $value, $case_sensitive) {
     $field = "LOWER({$field_name})";
     $escaped_value = db_escape_string(strtolower($value));
   }
+  // Add more fields here if needed.
   $result = db_query("
     SELECT
       phpbb_users.user_id,
       phpbb_users.username,
+      phpbb_users.user_email,
       phpbb_users.user_active
     FROM phpbb_users
     WHERE {$field} = '{$escaped_value}'
@@ -163,13 +165,13 @@ function validate_password(
 }
 
 
-function send_registration_email_in_use_email($email) {
+function send_email_address_in_use_email($email) {
   $user = get_user_by_field('user_email', $email, false);
 
   send_email(
     [$email],
-    'registration_email_in_use_email',
-    'Registration request: email address is already in use',
+    'email_address_in_use_email',
+    'FZC account notice: email address is already in use',
     [
       'username' => $user['username'],
       'reset_url' => url("/password_reset.php"),
@@ -247,12 +249,12 @@ function verify_activation_key($activation_key) {
 }
 
 
-function send_activation_email($email, $activation_key) {
-  $user = get_user_by_field('user_email', $email, false);
+function send_activation_email($user_id, $activation_key) {
+  $user = get_user_by_field('user_id', $user_id, false);
   $url_safe_activation_key = urlencode($activation_key);
 
   send_email(
-    [$email],
+    [$user['user_email']],
     'activation_email',
     'Activating your FZC account',
     [

--- a/common.php
+++ b/common.php
@@ -10,10 +10,17 @@ require_once __DIR__ . '/urls.php';
 
 session_start();
 
-if (isset($_SESSION['current_user_id'])) {
-  $current_user_id = intval($_SESSION['current_user_id']);
-  $current_user = mysqli_fetch_assoc(db_query("SELECT * FROM phpbb_users WHERE phpbb_users.user_id = $current_user_id"));
+
+function get_current_user_from_db() {
+  global $current_user_id, $current_user;
+
+  if (isset($_SESSION['current_user_id'])) {
+    $current_user_id = intval($_SESSION['current_user_id']);
+    $current_user = mysqli_fetch_assoc(db_query("SELECT * FROM phpbb_users WHERE phpbb_users.user_id = $current_user_id"));
+  }
 }
+get_current_user_from_db();
+
 
 class Project_Twig_Extension extends \Twig\Extension\AbstractExtension {
   public function getFilters() {

--- a/email.php
+++ b/email.php
@@ -14,7 +14,7 @@ function send_email($recipient_addresses, $template, $subject, $params) {
 
   if ($config['app']['debug']) {
     // Write emails to a text file instead of sending
-    $recipients_str = implode(', ', $recipients);
+    $recipients_str = implode(', ', $recipient_addresses);
     log_entry(
       'debug_emails.log',
       "{$recipients_str}\n-----\n{$subject}"

--- a/migrations/20240730120000_add-last-username-change.sql
+++ b/migrations/20240730120000_add-last-username-change.sql
@@ -1,0 +1,1 @@
+ALTER TABLE phpbb_users ADD COLUMN last_username_change DATETIME;

--- a/public/activation_resend.php
+++ b/public/activation_resend.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $user = get_user_by_field('user_email', $email, false);
   if ($user) {
     $activation_key = create_activation_key($user['user_id']);
-    send_activation_email($email, $activation_key);
+    send_activation_email($user['user_id'], $activation_key);
   }
   // Else, send no email (to be consistent with reset-password). Another
   // reasonable action here would be to send a notice email saying that

--- a/public/email_change.php
+++ b/public/email_change.php
@@ -1,0 +1,72 @@
+<?php
+
+require_once '../common.php';
+require_once '../account_utils.php';
+
+
+if ($current_user == NULL) {
+  die("You have to login to view this page");
+}
+
+$template = $twig->load('email_change.html');
+
+$user_id = intval($current_user['user_id']);
+$current_email = $current_user['user_email'];
+
+$render_args = [
+  'page_class' => 'page-email-change',
+  'PAGE_TITLE' => 'Change email address',
+  'current_email' => $current_email,
+];
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+
+  $desired_email = trim($_POST['email']);
+  try {
+    $email_validation_result = validate_email_address($desired_email);
+  }
+  catch (EmailValidationException $exception) {
+    $errors[] = $exception->getMessage();
+    $email_validation_result = EmailValidation::Error;
+  }
+
+  if (count($errors) > 0) {
+    // There were errors; the form will be redisplayed with previously
+    // submitted field values.
+    $render_args['previous_values'] = $_POST;
+  }
+  elseif ($email_validation_result === EmailValidation::AlreadyInUse) {
+    send_email_address_in_use_email($desired_email);
+
+    $render_args['is_sending_email'] = true;
+    $render_args['desired_email'] = $desired_email;
+  }
+  else {
+    // Set new email address in the database
+    db_update_by(
+      'phpbb_users', ['user_email' => $desired_email], ['user_id' => $user_id]);
+
+    // Deactivate account
+    db_update_by(
+      'phpbb_users', ['user_active' => 0], ['user_id' => $user_id]);
+
+    // Send activation email to new email address
+    $activation_key = create_activation_key($user_id);
+    send_activation_email($user_id, $activation_key);
+
+    // Ideally send a notice email to the old email address, but maybe
+    // saving that effort for the upcoming FZC instead.
+
+    // Probably makes sense to force-logout here, but not
+    // strictly necessary.
+
+    // And the displayed page should say what's going on and what
+    // to do next.
+    $render_args['is_sending_email'] = true;
+    $render_args['desired_email'] = $desired_email;
+  }
+}
+
+$render_args['errors'] = $errors;
+echo render_template($template, $render_args);

--- a/public/fzero.css
+++ b/public/fzero.css
@@ -1042,7 +1042,8 @@ p.header {
   text-align: center;
 }
 
-.page-login, .page-register, .page-password-change, .page-email-change {
+.page-login, .page-register, .page-password-change, .page-email-change,
+.page-username-change {
   & .error { background-color: pink; border: 1px solid red; padding: 3px 0px; }
 }
 

--- a/public/fzero.css
+++ b/public/fzero.css
@@ -1042,7 +1042,7 @@ p.header {
   text-align: center;
 }
 
-.page-login, .page-register, .page-password-change {
+.page-login, .page-register, .page-password-change, .page-email-change {
   & .error { background-color: pink; border: 1px solid red; padding: 3px 0px; }
 }
 

--- a/public/register.php
+++ b/public/register.php
@@ -64,7 +64,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $render_args['previous_values'] = $_POST;
   }
   elseif ($email_validation_result === EmailValidation::AlreadyInUse) {
-    send_registration_email_in_use_email($email);
+    send_email_address_in_use_email($email);
 
     $render_args['sending_email'] = true;
   }
@@ -95,7 +95,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Send activation email
     $activation_key = create_activation_key($user_id);
-    send_activation_email($email, $activation_key);
+    send_activation_email($user_id, $activation_key);
     $render_args['sending_email'] = true;
   }
 }

--- a/public/username_change.php
+++ b/public/username_change.php
@@ -1,0 +1,76 @@
+<?php
+
+require_once '../common.php';
+require_once '../account_utils.php';
+
+
+$utc_timezone = new DateTimeZone('UTC');
+
+
+function can_change_username($user) {
+  $last_change = $user['last_username_change'];
+  if (!$last_change) {
+    // Never changed before.
+    return true;
+  }
+
+  $change_date = date_create($last_change, $utc_timezone);
+  $now = date_create('now', $utc_timezone);
+  // Can change if the last change was over 14 days ago.
+  return ($now > date_add($change_date, new DateInterval('P14D')));
+}
+
+if ($current_user == NULL) {
+  die("You have to login to view this page");
+}
+
+$template = $twig->load('username_change.html');
+
+$user_id = intval($current_user['user_id']);
+
+$render_args = [
+  'page_class' => 'page-username-change',
+  'PAGE_TITLE' => 'Change username',
+];
+$errors = [];
+
+if (!can_change_username($current_user)) {
+
+  $render_args['cant_change'] = true;
+}
+elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
+
+  $desired_username = trim($_POST['username']);
+  // Collapse multiple spaces
+  $desired_username = preg_replace('/\s+/', ' ', $desired_username);
+  // Error checks
+  $username_error = validate_username($desired_username);
+  if ($username_error) {
+    $errors[] = $username_error;
+  }
+
+  if (count($errors) > 0) {
+    // There were errors; the form will be redisplayed with previously
+    // submitted field values.
+    $render_args['previous_values'] = $_POST;
+  }
+  else {
+    // Set new username in the database.
+    db_update_by(
+      'phpbb_users', ['username' => $desired_username], ['user_id' => $user_id]);
+
+    // Set 'last username change' date.
+    $now_str = date_create('now', $utc_timezone)->format('Y-m-d H:i:s');
+    db_update_by(
+      'phpbb_users', ['last_username_change' => $now_str], ['user_id' => $user_id]);
+
+    // Ensure the 'current user' vars are refreshed for the template, including
+    // for the base template's usages.
+    get_current_user_from_db();
+
+    $render_args['success'] = true;
+  }
+}
+
+$render_args['errors'] = $errors;
+echo render_template($template, $render_args);

--- a/templates/activation_resend.html
+++ b/templates/activation_resend.html
@@ -13,7 +13,7 @@
     </p>
 
     <form method='post'>
-      <p>Email address: <input type='email' name='email' /></p>
+      <p>Email address: <input type='email' name='email' required /></p>
       <p><input type='submit' value='Send' /></p>
     </form>
 

--- a/templates/email_address_in_use_email.html
+++ b/templates/email_address_in_use_email.html
@@ -1,5 +1,5 @@
 <p>Hi,</p>
 
-<p>A request has been made to register an F-Zero Central account with this email address. However, the existing account '{{ username|e }}' already uses this email address.</p>
+<p>A request has been made to associate an F-Zero Central account with this email address. However, the existing account '{{ username|e }}' already uses this email address.</p>
 <p>If you forgot your password, you can reset it here: <a href="{{ reset_url|e }}">{{ reset_url|e }}</a></p>
 <p>If you didn't request this, please ignore this email.</p>

--- a/templates/email_address_in_use_email.txt
+++ b/templates/email_address_in_use_email.txt
@@ -1,0 +1,7 @@
+Hi,
+
+A request has been made to associate an F-Zero Central account with this email address. However, the existing account '{{ username }}' already uses this email address.
+
+If you forgot your password, you can reset it here: {{ reset_url }}
+
+If you didn't request this, please ignore this email.

--- a/templates/email_change.html
+++ b/templates/email_change.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<div class="section-box">
+  {% if is_sending_email %}
+
+    <p>A reactivation email should have been sent to {{ desired_email }}. If you didn't get an email, please contact an admin for help.</p>
+
+  {% else %}
+    <p class='header'>
+      Change your email address
+    </p>
+
+    <p>Your current email address is: {{ current_email }}</p>
+
+    <p>Once you submit this form, we'll need to verify your new email address. To do that, your account will be temporarily deactivated, and we'll send a reactivation email to your new email address. So, double-check that you've entered your new email address correctly.</p>
+
+    {% if errors %}
+      {% for error in errors %}
+        <p class='error'>{{ error|e }}</p>
+      {% endfor %}
+    {% endif %}
+
+    <form method='post'>
+      <p>New email address: <input type='email' name='email' value='{{ previous_values.email }}' required /></p>
+      <p><input type='submit' value='Submit' /></p>
+    </form>
+
+  {% endif %}
+</div>
+
+{% endblock %}

--- a/templates/password_reset.html
+++ b/templates/password_reset.html
@@ -10,7 +10,7 @@
     <p>We sent you an email with a link that you can use to reset your password.</p>
   {% else %}
     <form method='post'>
-      <p>Email: <input type='text' name='email' /></p>
+      <p>Email: <input type='text' name='email' required /></p>
       <p><input type='submit' value='Reset' /></p>
 
       <p>If you remembered your password, <a href='/login.php'>Login</a> instead</p>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -22,8 +22,7 @@
 
   <p>
     Email address: {{ email_address }}
-    <br />
-    Contact the admin if you'd like to change this.
+    (<a href='/email_change.php'>Change</a>)
   </p>
 
   <p>Date registered: {{ registration_date }}</p>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -21,6 +21,11 @@
   <hr />
 
   <p>
+    Username: {{ current_user.username }}
+    (<a href='/username_change.php'>Change</a>)
+  </p>
+
+  <p>
     Email address: {{ email_address }}
     (<a href='/email_change.php'>Change</a>)
   </p>

--- a/templates/registration_email_in_use_email.txt
+++ b/templates/registration_email_in_use_email.txt
@@ -1,7 +1,0 @@
-Hi,
-
-A request has been made to register an F-Zero Central account with this email address. However, the existing account '{{ username }}' already uses this email address.
-
-If you forgot your password, you can reset it here: {{ reset_url }}
-
-If you didn't request this, please ignore this email.

--- a/templates/username_change.html
+++ b/templates/username_change.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<div class="section-box">
+  {% if cant_change %}
+
+    <p>It has been less than 2 weeks since your last username change ({{ current_user.last_username_change }}), so you can't change it again yet.</p>
+
+  {% elseif success %}
+
+    <p>Your username is now: {{ current_user.username }}</p>
+
+  {% else %}
+    <p class='header'>
+      Change your username
+    </p>
+
+    <p>Note: Once you change your username, you can't change it again for the next 2 weeks.</p>
+
+    {% if errors %}
+      {% for error in errors %}
+        <p class='error'>{{ error|e }}</p>
+      {% endfor %}
+    {% endif %}
+
+    <form method='post'>
+      <p>New username: <input type='text' name='username' value='{{ previous_values.username }}' required /></p>
+      <p><input type='submit' value='Submit' /></p>
+    </form>
+
+  {% endif %}
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Email address change reuses functionality from account activation, in order to verify the new email address. It's a little bit lazy, but also nice to avoid adding significantly more code for this (thus increasing surface area for bugs, etc).

Username change can be done once per 2 weeks.