### PR TITLE
Server admin ability to send one-off emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /cache/*
 /config.ini
 /log/*
+/templates/untracked/*

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You must create a `config.ini` file at the root of the repo and define certain v
 base_url = http://127.0.0.1:8000
 hmac_key = "around50randomlettersnumbersandsymbols^+_(&@-!*)"
 debug = true
+server_admin_usernames[] = "FZC username to notify by email of certain server events"
+server_admin_usernames[] = "Another such username; add as many as desired"
 notice_bar_message = "This message appears on a bar above the social media buttons. If this variable is omitted entirely, the bar won't show."
 
 [database]

--- a/tools/send-one-off-email.php
+++ b/tools/send-one-off-email.php
@@ -1,0 +1,60 @@
+<?php
+
+// Send a one-off email, from the FZC admin email address, to the email address
+// of the user with the passed username.
+
+require_once __DIR__ . '/../account_utils.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../email.php';
+
+
+$email_template_name = $argv[1];
+$subject = $argv[2];
+$username = $argv[3];
+
+if ($email_template_name === NULL) {
+  die("Pass the email template name as the first argument.");
+}
+if ($subject === NULL) {
+  die("Pass the email subject as the second argument.");
+}
+if ($username === NULL) {
+  die("Pass the target user's username as the third argument.");
+}
+
+$user = get_user_by_field('username', $username, true);
+if ($user === NULL) {
+  die("This user doesn't exist.");
+}
+$email_address = $user['user_email'];
+
+$server_admin_usernames = $config['app']['server_admin_usernames'];
+$server_admin_email_addresses = array_map(
+  function($admin_username) {
+    $admin_user = get_user_by_field('username', $admin_username, true);
+    return $admin_user['user_email'];
+  },
+  $server_admin_usernames,
+);
+
+// For the main recipient.
+send_email(
+  [$email_address],
+  $email_template_name,
+  $subject,
+  [
+    'username' => $username,
+  ]
+);
+
+// Admin copies.
+send_email(
+  $server_admin_email_addresses,
+  $email_template_name,
+  "[FZC one-off email: Admin's copy] " . $subject,
+  [
+    'username' => $username,
+  ]
+);
+
+echo "Sent.";


### PR DESCRIPTION
Here's how you would use this functionality to send an email to the user whose username is `user1`:

- Add a new file, `templates/untracked/my_email.txt`, on the server. The contents should be the body of the email. The placeholder `{{ username }}` is allowed in the email body; the actual username will be substituted in there.
- On the server, cd to this repo's root, then run this command: `php tools/send-one-off-email.php "untracked/my_email" "Subject goes here" "user1"`

As a result, an email with the specified body and subject should get sent to the email address on file for user1. Also, a copy of the email will be sent to any users specified in the site config's `server_admin_usernames`. This is done in such a way that the main recipient and the admins cannot see each other's email addresses.