### PR TITLE
Two 'see also' links

### DIFF
--- a/data/games/gpl.xml
+++ b/data/games/gpl.xml
@@ -2,4 +2,10 @@
 <game>
   <name>F-Zero: GP Legend</name>
   <rules_template>rules/gpl.html</rules_template>
+  <home_see_also>
+    <link>
+      <display>Speedrun.com rankings for e-Reader tracks</display>
+      <url>https://www.speedrun.com/fzgpl/levels</url>
+    </link>
+  </home_see_also>
 </game>

--- a/data/games/gx.xml
+++ b/data/games/gx.xml
@@ -8,8 +8,8 @@
       <url>https://docs.google.com/spreadsheets/d/10mZeQrMLaaPMdC0ZeKR2Wk1XtzICG2n4XTw9yyx-dKw/edit#gid=488310816</url>
     </link>
     <link>
-      <display>Per-machine records (Max speed)</display>
-      <url>https://docs.google.com/spreadsheets/d/17DqpOEgzh0RqSKZ-5q5kanhI3uRhQ6w0xo4GTJO5cQI/edit</url>
+      <display>Machines vs. staff ghosts (per-machine records)</display>
+      <url>https://drive.google.com/drive/u/0/folders/1rvX8jeMN2GvHhyNh0AGC_ctTMKD04JnY</url>
     </link>
   </home_see_also>
 </game>


### PR DESCRIPTION
- Update GX machines vs. staff ghosts link.
- Add link to speedrun.com rankings for GPL e-Reader tracks.