### PR TITLE
Fix PAL detection

### DIFF
--- a/src/fzero.php
+++ b/src/fzero.php
@@ -73,7 +73,7 @@ function ladder_pal_ratio($ladder) {
 }
 
 function user_prefers_pal($user) {
-  preg_match('/F0Pal/', $user['user_interests']);
+  return preg_match('/F0Pal/', $user['user_interests']);
 }
 
 function ntsc_to_user_time($ladder, $user, $time) {


### PR DESCRIPTION
Fix detection of PAL user-preference values that were set in the past.

Only had to add a `return` keyword. Not sure if this was a bug or an intentional code change to disable PAL; but in any case, I couldn't think of a reason to keep it disabled, other than the fact that there's no UI to toggle the preference yet (that can be implemented later, and perhaps toggling is rare enough these days that I'm OK with setting the preference on request for some time).

For the record, here's how the PAL setting currently works:

- If the `user_interests` database field has the string `F0Pal` within it, then the user's region is considered to be PAL; else, it's considered to be NTSC. So this is the field I'd be setting manually if someone wants to change.
- Ladders always show NTSC (and PAL-converted-to-NTSC) times. The database also always stores NTSC times.
- The only thing the region affects is what the player sees on the record-submission page (client.php). If region is PAL, then FZC grabs their converted-to-NTSC times (and speeds in X) from the database, multiplies by the game's conversion factor (e.g. 6/5 for X times) to convert back to PAL, and then displays the converted-back-to-PAL records in the form fields. The player is supposed to enter their new PAL times and then submit the form, and then FZC again converts those times to NTSC to save to the database.
- The same PAL setting is applied to both SNES and X. You can't pick, say, NTSC SNES and PAL X at the same time.

And it's worth pointing out the major caveats of this system:

- There are elements of unfairness in directly comparing PAL and NTSC times this way, which is why the plan for the next FZC website is to have them ranked separately (if not on the site's launch, then reasonably soon after): https://github.com/fzerocentral/fzerocentral-api/issues/4
- It's likely for the PAL -> NTSC -> PAL conversion process to produce times that are off by 0"01 or 0"001. For example, if you submit a PAL time of 1'11"115 in X, that'll be converted to 59"263 NTSC upon submission, and then that'll be converted to 1'11"116 PAL upon visiting the record-submission page again. I don't think this can make the NTSC-converted times shift by 1, but it can cause confusion when you go to edit times.