### PR TITLE
Add param checks to `FserverGame()` and other functions

### DIFF
--- a/src/fzero.php
+++ b/src/fzero.php
@@ -126,15 +126,28 @@ function ship_image_url($ship_name) {
 }
 
 function FserverGame($game_shortcode) {
+  // Only allow letters/numbers, not stuff like slashes and double-dots.
+  if (!ctype_alnum($game_shortcode)) {
+    die("Invalid game shortcode: $game_shortcode");
+  }
+
   $file = __DIR__ . "/../data/games/$game_shortcode.xml";
   $game = simplexml_load_file($file);
+  if ($game === false) {
+    die("Unsupported game shortcode: $game_shortcode");
+  }
 
   return $game;
 }
 
 function FserverLadder($ladder_id) {
+  $ladder_id = intval($ladder_id);
+
   $file = __DIR__ . "/../data/ladders/ladder$ladder_id.xml";
   $ladder = simplexml_load_file($file);
+  if ($ladder === false) {
+    die("Unsupported ladder ID: $ladder_id");
+  }
 
   return $ladder;
 }
@@ -168,6 +181,8 @@ function FserverGetActivePlayers($ladder_id) {
 
 function FserverGetUserData($ladder_id, $user_id, $current_user, $ladder) {
   global $db;
+  $ladder_id = intval($ladder_id);
+  $user_id = intval($user_id);
 
   $output = [
     'user_id' => $user_id,

--- a/src/fzero/recalc.php
+++ b/src/fzero/recalc.php
@@ -35,6 +35,7 @@ $ferris_beuller_id = 222;
 
 function recalc_ladder_totals($ladder_id) {
   global $ferris_beuller_id;
+  $ladder_id = intval($ladder_id);
 
   db_delete_by('phpbb_f0_totals', ['ladder_id' => $ladder_id]);
 
@@ -81,6 +82,8 @@ function recalc_ladder_totals($ladder_id) {
 }
 
 function recalc_af($ladder_id) {
+  $ladder_id = intval($ladder_id);
+
   if ($ladder_id == 9) {
     recalc_af_9();
     return;
@@ -277,6 +280,8 @@ $ladder_srpr_weights = [
 ];
 
 function recalc_srpr($ladder_id) {
+  $ladder_id = intval($ladder_id);
+
   if ($ladder_id == 9) {
     recalc_srpr_9();
     return;


### PR DESCRIPTION
Add param checks in a few functions that construct filepaths and DB queries.

The game shortcode case (`FserverGame()`) could be the only case that really needs the added check in its actual usages. But in the absence of a really separated database layer, these simple checks feel like warranted defensive coding.