### PR TITLE
Platform options for all ladders + related rules and layouts updates

### DIFF
--- a/data/ladders/ladder1.xml
+++ b/data/ladders/ladder1.xml
@@ -79,4 +79,13 @@
 	<ship>Wild Goose</ship>
 	<ship>Fire Stingray</ship>
 	</ships>
+  <platforms>
+   <platform>Cartridge</platform>
+   <platform>Flashcart</platform>
+	 <platform>Switch Online</platform>
+	 <platform>Wii VC</platform>
+	 <platform>Wii U VC</platform>
+	 <platform>3DS VC</platform>
+	 <platform>SNES Mini</platform>
+  </platforms>
 </game>

--- a/data/ladders/ladder11.xml
+++ b/data/ladders/ladder11.xml
@@ -109,4 +109,9 @@
  <ships>
   <ship>Blue Falcon</ship>
  </ships>
+ <platforms>
+  <platform>Disc</platform>
+  <platform>USB/SD Loader</platform>
+	<platform>Switch Online</platform>
+ </platforms>
 </game>

--- a/data/ladders/ladder12.xml
+++ b/data/ladders/ladder12.xml
@@ -109,4 +109,9 @@
  <ships>
   <ship>Blue Falcon</ship>
  </ships>
+ <platforms>
+  <platform>Disc</platform>
+  <platform>USB/SD Loader</platform>
+	<platform>Switch Online</platform>
+ </platforms>
 </game>

--- a/data/ladders/ladder13.xml
+++ b/data/ladders/ladder13.xml
@@ -210,4 +210,10 @@
   <ship>Elegance Liberty</ship>
   <ship>Moon Shadow</ship>
  </ships>
+ <platforms>
+  <platform>Cartridge</platform>
+  <platform>Flashcart</platform>
+  <platform>Switch Online</platform>
+  <platform>Wii U VC</platform>
+ </platforms>
 </game>

--- a/data/ladders/ladder14.xml
+++ b/data/ladders/ladder14.xml
@@ -186,4 +186,7 @@
 	<platform>Wii U VC</platform>
 	<platform>mGBA 0.8.x</platform>
  </platforms>
+ <obsolete_platforms>
+	<platform>GBA</platform>
+ </obsolete_platforms>
 </game>

--- a/data/ladders/ladder14.xml
+++ b/data/ladders/ladder14.xml
@@ -180,9 +180,10 @@
   <ship>Little Wyvern</ship>
  </ships>
  <platforms>
-  <platform>GBA</platform>
-	<platform>Wii U VC</platform>
+  <platform>Cartridge</platform>
+  <platform>Flashcart</platform>
 	<platform>Switch Online</platform>
+	<platform>Wii U VC</platform>
 	<platform>mGBA 0.8.x</platform>
  </platforms>
 </game>

--- a/data/ladders/ladder15.xml
+++ b/data/ladders/ladder15.xml
@@ -84,9 +84,10 @@
 	<ship>Little Wyvern</ship>
 </ships>
  <platforms>
-  <platform>GBA</platform>
-	<platform>Wii U VC</platform>
+  <platform>Cartridge</platform>
+  <platform>Flashcart</platform>
 	<platform>Switch Online</platform>
+	<platform>Wii U VC</platform>
 	<platform>mGBA 0.8.x</platform>
  </platforms>
 </game>

--- a/data/ladders/ladder15.xml
+++ b/data/ladders/ladder15.xml
@@ -90,4 +90,7 @@
 	<platform>Wii U VC</platform>
 	<platform>mGBA 0.8.x</platform>
  </platforms>
+ <obsolete_platforms>
+	<platform>GBA</platform>
+ </obsolete_platforms>
 </game>

--- a/data/ladders/ladder16.xml
+++ b/data/ladders/ladder16.xml
@@ -94,4 +94,8 @@
 <ship>Super Cat</ship>
 <ship>Custom Ship</ship>
 </ships>
+<platforms>
+ <platform>Cartridge</platform>
+ <platform>Flashcart</platform>
+</platforms>
 </game>

--- a/data/ladders/ladder17.xml
+++ b/data/ladders/ladder17.xml
@@ -52,4 +52,10 @@
 <ship>Black Bull</ship>
 <ship>Sonic Phantom</ship>
 </ships>
+<platforms>
+ <platform>Cartridge</platform>
+ <platform>Switch Online</platform>
+ <platform>Wii VC</platform>
+ <platform>Wii U VC</platform>
+</platforms>
 </game>

--- a/data/ladders/ladder18.xml
+++ b/data/ladders/ladder18.xml
@@ -544,5 +544,12 @@
   </ships>
 
 
+  <platforms>
+   <platform>Cartridge</platform>
+   <platform>Switch Online</platform>
+   <platform>Wii VC</platform>
+   <platform>Wii U VC</platform>
+  </platforms>
+
 
   </game>

--- a/data/ladders/ladder2.xml
+++ b/data/ladders/ladder2.xml
@@ -136,4 +136,10 @@
 	<ship>Black Bull</ship>
 	<ship>Sonic Phantom</ship>
 	</ships>
+  <platforms>
+   <platform>Cartridge</platform>
+	 <platform>Switch Online</platform>
+	 <platform>Wii VC</platform>
+	 <platform>Wii U VC</platform>
+  </platforms>
 </game>

--- a/data/ladders/ladder3.xml
+++ b/data/ladders/ladder3.xml
@@ -110,4 +110,11 @@
   <ship>Fighting Comet</ship>
   <ship>Jet Vermilion</ship>
  </ships>
+ <platforms>
+  <platform>Cartridge</platform>
+  <platform>Flashcart</platform>
+  <platform>Switch Online</platform>
+  <platform>Wii U VC</platform>
+  <platform>3DS VC</platform>
+ </platforms>
 </game>

--- a/data/ladders/ladder4.xml
+++ b/data/ladders/ladder4.xml
@@ -115,4 +115,9 @@
  </cups>
  <ships>
  </ships>
+ <platforms>
+  <platform>Disc</platform>
+  <platform>USB/SD Loader</platform>
+	<platform>Switch Online</platform>
+ </platforms>
 </game>

--- a/data/ladders/ladder5.xml
+++ b/data/ladders/ladder5.xml
@@ -115,4 +115,9 @@
  </cups>
  <ships>
  </ships>
+ <platforms>
+  <platform>Disc</platform>
+  <platform>USB/SD Loader</platform>
+	<platform>Switch Online</platform>
+ </platforms>
 </game>

--- a/data/ladders/ladder6.xml
+++ b/data/ladders/ladder6.xml
@@ -194,4 +194,10 @@
   <ship>Elegance Liberty</ship>
   <ship>Moon Shadow</ship>
  </ships>
+ <platforms>
+  <platform>Cartridge</platform>
+  <platform>Flashcart</platform>
+  <platform>Switch Online</platform>
+  <platform>Wii U VC</platform>
+ </platforms>
 </game>

--- a/data/ladders/ladder7.xml
+++ b/data/ladders/ladder7.xml
@@ -246,4 +246,7 @@
 	<platform>Wii U VC</platform>
 	<platform>mGBA 0.8.x</platform>
  </platforms>
+ <obsolete_platforms>
+	<platform>GBA</platform>
+ </obsolete_platforms>
 </game>

--- a/data/ladders/ladder7.xml
+++ b/data/ladders/ladder7.xml
@@ -240,9 +240,10 @@
   <ship>Little Wyvern</ship>
  </ships>
  <platforms>
-  <platform>GBA</platform>
-	<platform>Wii U VC</platform>
+  <platform>Cartridge</platform>
+  <platform>Flashcart</platform>
 	<platform>Switch Online</platform>
+	<platform>Wii U VC</platform>
 	<platform>mGBA 0.8.x</platform>
  </platforms>
 </game>

--- a/data/ladders/ladder8.xml
+++ b/data/ladders/ladder8.xml
@@ -115,4 +115,9 @@
  </cups>
  <ships>
  </ships>
+ <platforms>
+  <platform>Disc</platform>
+  <platform>USB/SD Loader</platform>
+	<platform>Switch Online</platform>
+ </platforms>
 </game>

--- a/public/fzero.css
+++ b/public/fzero.css
@@ -870,15 +870,17 @@ div.home-page-ladder-group > div.body > a:hover {
   border-spacing: 0px;
 }
 
+/* Alternate colors between rows. */
 .scoreboard .entries tr:nth-child(2n + 1) td { background-color: #e5e5e5;  }
 .scoreboard .entries tr:nth-child(2n) td { background-color: #f7f7f7;  }
 
+/* Rounded corners on the overall table. */
 .scoreboard thead td:first-child { border-radius: 10px 0px 0px 0px; }
 .scoreboard thead td:last-child { border-radius: 0px 10px 0px 0px; }
-
 .scoreboard .entries tr:last-child td:first-child { border-radius: 0px 0px 0px 10px; }
-.scoreboard .entries tr:last-child td:last-child{ border-radius: 0px 0px 10px 0px; }
+.scoreboard .entries tr:last-child td:last-child { border-radius: 0px 0px 10px 0px; }
 
+/* Header row specifics. */
 .scoreboard thead a { display: block; text-align: center; }
 .scoreboard thead a:hover { color: black; }
 .scoreboard thead td {
@@ -901,11 +903,61 @@ div.home-page-ladder-group > div.body > a:hover {
               );
 }
 
+.scoreboard .record-platform {
+  font-size: 0.85em;
+  /* Less vertical spacing. */
+  line-height: 0.85;
+  /* Don't word-wrap this. */
+  white-space: nowrap;
+}
+.scoreboard .record-rank,
+.scoreboard .record-date {
+  text-align: center;
+}
+.scoreboard .entries td.notes {
+  font-size: 0.85em;
+}
 
-.scoreboard .entries td:nth-child(n+2) {
-  border-left: 1px #a5a5a5 solid;
+/* Column dividers. */
+.scoreboard .entries td {
+  border-left: 1px hsl(0 0% 65%) solid;
+}
+
+.scoreboard td {
   padding: 5px;
 }
+.scoreboard td.position {
+  /*
+  Effectively increase the minimum row height, which should make the
+  row heights a bit closer to uniform. We do this by adding padding to
+  a cell that we don't expect to have more content than other cells in
+  its row.
+  */
+  padding: 8px 5px;
+}
+
+.scoreboard td.record-details,
+.scoreboard td.record-rank-date {
+  /* Lighter border between the record itself and its details. */
+  border-left: 1px hsl(0 0% 65% / 25%) solid;
+  /* The ship icon and proof icon should be on the same line. The platform's no-word-wrap rule probably makes this rule redundant most of the time, but still. */
+  min-width: 50px;
+}
+
+.scoreboard td.record-rank-date {
+  font-size: 0.92em;
+}
+
+.scoreboard .record-date,
+.scoreboard .record-platform,
+.scoreboard .record-rank {
+  /*
+  Indicate that mouse-overing for a bit will display additional info
+  or an explanation.
+  */
+  cursor: help;
+}
+
 
 .page-player-summary .championship-performance td { text-align: center; }
 .page-player-summary .ladder-performance td { text-align: center; }

--- a/public/fzero.css
+++ b/public/fzero.css
@@ -1126,23 +1126,6 @@ p.header {
 }
 
 
-.page-client .record-row {
-  display: grid;
-  margin-bottom: 2px;
-  grid-template: auto auto / repeat(5, auto);
-}
-
-.page-client .proof-container {
-  padding: 2px;
-  border: 1px solid #b53b35;
-  margin-top: 6px;
-  margin-bottom: 6px;
-  background-color: #fffada;
-  grid-column-start: 1;
-  grid-column-end: span 5;
-  display: none;
-}
-
 .page-game .main-content {
   max-width: 960px;
   margin: 0px auto;

--- a/rules/gx.md
+++ b/rules/gx.md
@@ -25,7 +25,7 @@
 
 Due to the nature of how USB/SD loaders work, a few extra rules are needed to ensure no players obtain unexpected advantages over Disc users.
 
-Methods of USB/SD Loading allowed:
+Alternative game loading methods allowed:
 
 1. HDD or USB stick plugged to the back of a Wii
 1. SD Card inserted in the front slot of a Wii
@@ -33,8 +33,9 @@ Methods of USB/SD Loading allowed:
 1. GCLoader Drive Replacement installed on GameCube
 1. SD Card inserted in the front slot of a Wii U
 1. HDD or USB stick plugged to a USB port on a Wii U
+1. Self-burned disc (not a USB/SD loader, but we group it here because similar concerns apply)
 
-Only these methods have been verified by the Staff and enough testing has been conducted to ensure times set using them are identical to times set with a Disc.
+Only these methods have been verified by the Staff and enough testing has been conducted to ensure times set using them are identical to times set with a Disc. If you use any of these loading methods, specify a Platform of "USB/SD Loader" when submitting records.
 
 Rules regarding usage of the game:
 

--- a/rules/gx.md
+++ b/rules/gx.md
@@ -2,8 +2,9 @@
 
     - The original GameCube game disc
     - A USB or SD loader, with an unaltered ISO of the original game - see the **USB/SD Loader Rules** below
+    - The Switch Online release on the Switch 2 - the **Save State Rules** below apply to suspend points
 
-    Emulators (such as Dolphin) are not allowed.
+    Unofficial emulators (such as Dolphin) are not allowed.
 
 1. Course Times and Speeds must be obtained using Time Attack mode. Lap Times must be obtained with either Time Attack mode or Practice mode with CPUs off.
 
@@ -42,6 +43,15 @@ Rules regarding usage of the game:
 1. Additional proof for times will be required in the form of Replay files. through testing, it's been determined that Replay files will only sync with game versions that don't have any modifications to machine stats. this ensures players won't be editing the game's files. as a side effect, Story Mode times set on USB/SD Loaders won't be allowed because this form of proof can't be obtained from that mode.
 
 1. USB/SD Loader software such as Nintendont usually comes with functionality for cheat codes. make sure they are turned off when setting times. you're allowed to unlock the Event Parts (Gold Parts) in the same way it is done with Action Replay.
+
+
+## Save State Rules
+
+When submitting runs to the FZC ladder, save states, restore points, etc. may only be used as described below.
+
+**3-Laps:** Before the timer of the 3-lap attempt first starts.
+
+**Fast Laps:** Before Boost Power and/or any advanced technique is performed that leads into the fast lap being attempted. For example, if the lap setup involves spaceflying, the save state must be made on the ground before the snaking and flying movements of the setup.
 
 
 ## Max Speed Ladder

--- a/rules/x.md
+++ b/rules/x.md
@@ -3,7 +3,7 @@
     - The original Nintendo 64 game cartridge
     - The Wii Virtual Console release
     - The Wii U Virtual Console release - the **Save State Rules** below apply to restore points
-    - The Switch Online release - the **Save State Rules** below apply to suspend points
+    - The Switch Online release - the **Save State Rules** below apply to suspend points and rewinds
     - (**Expansion Kit Ladder only**) A flash cartridge ("Flashcart"), with an unaltered ROM of the original game - see the **Flashcart Rules** and **Save State Rules** below
 
     Unofficial emulators are not allowed. Flashcarts are not allowed for ladders other than the Expansion Kit Ladder.

--- a/templates/client.html
+++ b/templates/client.html
@@ -211,10 +211,63 @@
     return;
   }
 
+  function validateRecords(event) {
+    let recordRows = document.querySelectorAll('div.record-row');
+
+    for (let recordRow of recordRows) {
+      let platformField = recordRow.querySelector('.platform-container select');
+      let valueFields =
+        recordRow.querySelector('div.value-fields').querySelectorAll('input');
+
+      if (platformField.value !== '') {
+        // Platform is filled in.
+        continue;
+      }
+
+      // Platform is not filled in. We want to require it for any new/updated
+      // record from now on, so we proceed to check if we have such a
+      // record.
+      // Specifically, by checking if the value or the platform is being
+      // updated, we should cover all relevant cases.
+      //
+      // Note that checking this only in Javascript means it can be defeated
+      // with inspect element. Though, if someone really took the trouble to
+      // do that to avoid specifying a platform, that would be annoying
+      // but not site-breaking.
+
+      for (let field of [platformField, ...valueFields]) {
+        if (field.value != field.dataset.originalValue) {
+          // Value or platform has been changed, and platform is blank as
+          // established above. Therefore we prevent submission.
+          event.preventDefault();
+
+          // This is an ancestor element
+          let courseContainer = recordRow.closest('div.course-container');
+          let courseName =
+            courseContainer.querySelector('div.course-name').textContent.trim();
+          // This has a colon at the end, but we don't bothering trimming it
+          // since it's OK for our alert string purposes.
+          let recordTypeWithColon =
+            recordRow.querySelector('div.value-label').textContent.trim();
+          window.alert(
+            `${courseName} - ${recordTypeWithColon} Please specify a platform.`);
+
+          return;
+        }
+      }
+
+      // If reached here, no platforms are blank for the records we're
+      // concerned with, so submission can proceed.
+    }
+  }
+
   function togglePal() {
     if (confirm("You will lose unsaved edits. OK?")) {
       location.href = '/f0/toggle_pal.php?ladder={{ ladder_id }}&user={{ user_id }}';
     }
   }
+
+  let form = document.querySelector('form[name="user_data"]');
+  form.addEventListener('submit', validateRecords);
 </script>
 {% endblock %}

--- a/templates/client.html
+++ b/templates/client.html
@@ -219,20 +219,28 @@
       let valueFields =
         recordRow.querySelector('div.value-fields').querySelectorAll('input');
 
-      if (platformField.value !== '') {
-        // Platform is filled in.
+      let potentialError = null;
+      if (platformField.value === '') {
+        potentialError = "Please specify a platform.";
+      }
+      else if (platformField.value === 'GBA') {
+        potentialError = "GBA is a legacy platform choice for this ladder. Please choose either Cartridge or Flashcart instead.";
+      }
+      else {
+        // Platform is filled in with a non-legacy value, so none of our
+        // error checks apply.
         continue;
       }
 
-      // Platform is not filled in. We want to require it for any new/updated
-      // record from now on, so we proceed to check if we have such a
-      // record.
+      // Platform is not filled in with a non-legacy value. We want to require
+      // that for any new/updated record from now on, so we proceed to check
+      // if we have such a record.
       // Specifically, by checking if the value or the platform is being
       // updated, we should cover all relevant cases.
       //
       // Note that checking this only in Javascript means it can be defeated
       // with inspect element. Though, if someone really took the trouble to
-      // do that to avoid specifying a platform, that would be annoying
+      // do that to specify a blank or GBA platform, that would be annoying
       // but not site-breaking.
 
       for (let field of [platformField, ...valueFields]) {
@@ -250,7 +258,7 @@
           let recordTypeWithColon =
             recordRow.querySelector('div.value-label').textContent.trim();
           window.alert(
-            `${courseName} - ${recordTypeWithColon} Please specify a platform.`);
+            `${courseName} - ${recordTypeWithColon} ${potentialError}`);
 
           return;
         }

--- a/templates/client.html
+++ b/templates/client.html
@@ -51,6 +51,12 @@
     padding-right: 10px;
   }
 
+  div.record-row {
+    display: grid;
+    margin-bottom: 2px;
+    grid-template: auto auto / repeat(6, auto);
+  }
+
   div.record-row > div {
     padding: 0 3px;
   }
@@ -68,7 +74,22 @@
   div.record-row > div.value-fields {
     /* Ensure the space for the fields is the same width, whether it's a time
        or a speed. */
-    width: 120px;
+    width: 100px;
+  }
+
+  /* Sizing for small input fields in particular seems to vary quite a bit
+     between browsers when relying on the 'size' attribute. So we use styling instead. */
+  input.value-1ch {
+    width: 20px;
+  }
+  input.value-2ch {
+    width: 27px;
+  }
+  input.value-3ch {
+    width: 34px;
+  }
+  input.value-4ch {
+    width: 41px;
   }
 
   div.record-row > div.splits-comments-container {
@@ -96,6 +117,17 @@
     display: inline-block;
     font-size: 7pt;
     cursor: pointer;
+  }
+
+  div.proof-container {
+    padding: 2px;
+    border: 1px solid #b53b35;
+    margin-top: 6px;
+    margin-bottom: 6px;
+    background-color: #fffada;
+    grid-column-start: 1;
+    grid-column-end: span 6;
+    display: none;
   }
   div.proof-indicator.hidden {
     display: none;

--- a/templates/course.html
+++ b/templates/course.html
@@ -33,53 +33,91 @@
     <thead>
       <tr>
         <td colspan='2'>Player</td>
-        <td>Course time</td>
-        <td>Best lap</td>
-        {% if ladder.hasspeed == 'Yes' %}<td>Max speed</td>{% endif %}
-        <td></td>
+        <td colspan='2'>Course time</td>
+        {% if ladder.haslap == 'Yes' %}
+          <td colspan='2'>Best lap</td>
+        {% endif %}
+        {% if ladder.hasspeed == 'Yes' %}
+          <td colspan='2'>Max speed</td>
+        {% endif %}
+        <td>Notes</td>
       </tr>
     </thead>
 
     <tbody class='entries'>
       {% for entry in entries %}
         <tr>
-          <td>
+
+          <td class="position">
             {{ entry.position}}.
           </td>
+
           <td>
             {{ entry.location|flag }}
             <a href='viewplayer.php?ladder={{ ladder_id }}&user={{ entry.user_id }}'>{{ entry.username|e }}</a>
           </td>
+
           <td>
-            <span>{{ entry.course_value|format_time(ladder.timeformat) }}</span>
-            <img src="{{ entry.course_ship_image|e }}" title="{{ entry.course_ship }}" />
-            {% if entry.course_has_proof %}
-              {{ entry | proof_link("course_") }}
-            {% endif %}
-            <span>{{ entry.course_platform }}</span>
+            {{ entry.course_value|format_time(ladder.timeformat) }}
           </td>
-          <td>
-            {% if ladder.haslap == 'Yes' %}
-              <span>{{ entry.lap_value|format_time(ladder.timeformat) }}</span>
-              <img src="{{ entry.lap_ship_image|e }}" title="{{ entry.lap_ship }}" />
-              {% if entry.lap_has_proof %}
-                {{ entry | proof_link("lap_") }}
+
+          <td class="record-details">
+            <div class="record-ship-proof">
+              <img src="{{ entry.course_ship_image|e }}" title="{{ entry.course_ship }}" />
+              {% if entry.course_has_proof %}
+                {{ entry | proof_link("course_") }}
               {% endif %}
-            {% endif %}
+            </div>
+            <div class="record-platform" title="Platform this record was achieved on">
+              {{ entry.course_platform }}
+            </div>
           </td>
-          {% if ladder.hasspeed == 'Yes' %}
+
+          {% if ladder.haslap == 'Yes' %}
             <td>
-              <span>{{ entry.speed_value }}</span>
-              <img src="{{ entry.speed_ship_image|e }}" title="{{ entry.speed_ship }}" />
-              {% if entry.speed_has_proof %}
-                {{ entry | proof_link("speed_") }}
-              {% endif %}
+              {{ entry.lap_value|format_time(ladder.timeformat) }}
+            </td>
+
+            <td class="record-details">
+              <div class="record-ship-proof">
+                <img src="{{ entry.lap_ship_image|e }}" title="{{ entry.lap_ship }}" />
+                {% if entry.lap_has_proof %}
+                  {{ entry | proof_link("lap_") }}
+                {% endif %}
+              </div>
+              <div class="record-platform" title="Platform this record was achieved on">
+                {{ entry.lap_platform }}
+              </div>
             </td>
           {% endif %}
-          <td>
-            {% if entry.course_notes != '' %}<div>{{ entry.course_notes|e }}</div>{% endif %}
-            {% if entry.lap_notes != '' %}<div>{{ entry.lap_notes|e }}</div>{% endif %}
+
+          {% if ladder.hasspeed == 'Yes' %}
+            <td>
+              {{ entry.speed_value }}
+            </td>
+
+            <td class="record-details">
+              <div class="record-ship-proof">
+                <img src="{{ entry.speed_ship_image|e }}" title="{{ entry.speed_ship }}" />
+                {% if entry.speed_has_proof %}
+                  {{ entry | proof_link("speed_") }}
+                {% endif %}
+              </div>
+              <div class="record-platform" title="Platform this record was achieved on">
+                {{ entry.speed_platform }}
+              </div>
+            </td>
+          {% endif %}
+
+          <td class="notes">
+            {% if entry.course_notes != '' %}
+              <div>{{ entry.course_notes|e }}</div>
+            {% endif %}
+            {% if entry.lap_notes != '' %}
+              <div>{{ entry.lap_notes|e }}</div>
+            {% endif %}
           </td>
+
         </tr>
       {% endfor %}
 

--- a/templates/ladder_latest.html
+++ b/templates/ladder_latest.html
@@ -16,7 +16,6 @@
         <td>Course</td>
         <td>Type</td>
         <td>Record</td>
-        <td>Rank</td>
         <td>Ship</td>
         <td>Platform</td>
         <td>Proof</td>
@@ -51,7 +50,6 @@
               {{ entry.value|format_time(ladder.timeformat) }}
             {% endif %}
           </td>
-          <td>{{ 1 }}</td>
           <td><img src="{{ entry.ship_image|e }}" title="{{ entry.ship }}" /></td>
           <td>{{ entry.platform }}</td>
           <td>{% if entry.has_proof %}{{ entry|proof_link }}{% endif %}</td>

--- a/templates/submission-entry.html
+++ b/templates/submission-entry.html
@@ -11,17 +11,17 @@
 
   <div class="value-fields">
     {% if sub_type != "S" %}
-      <input name='records[{{ field_prefix }}][time@m]' type='text' maxlength='1' size='1' value='{{ sub.time_m }}' data-original-value='{{ sub.time_m }}' />
+      <input name='records[{{ field_prefix }}][time@m]' type='text' class='value-1ch' maxlength='1' value='{{ sub.time_m }}' data-original-value='{{ sub.time_m }}' />
 
       {% with { value: sub.time_s|format_time_part("Seconds") } %}
-        <input name='records[{{ field_prefix }}][time@s]' type='text' maxlength='2' size='2' value='{{ value }}' data-original-value='{{ value }}' />
+        <input name='records[{{ field_prefix }}][time@s]' type='text' class='value-2ch' maxlength='2' value='{{ value }}' data-original-value='{{ value }}' />
       {% endwith %}
 
       {% with { value: sub.time_t|format_time_part("Subseconds", ladder.timeformat) } %}
-        <input name='records[{{ field_prefix }}][time@t]' type='text' maxlength='4' size='4' value='{{ value }}' data-original-value='{{ value }}' />
+        <input name='records[{{ field_prefix }}][time@t]' type='text' class='value-3ch' maxlength='3' value='{{ value }}' data-original-value='{{ value }}' />
       {% endwith %}
     {% else %}
-      <input name='records[{{ field_prefix }}][speed]' type='text' maxlength='6' size='6' value='{{ sub.speed }}' data-original-value='{{ sub.speed }}' />
+      <input name='records[{{ field_prefix }}][speed]' type='text' class='value-4ch' maxlength='4' value='{{ sub.speed }}' data-original-value='{{ sub.speed }}' />
     {% endif %}
   </div>
 
@@ -115,9 +115,9 @@
   <!-- Collapsible proof fields -->
   <div id='{{ field_prefix }}-proof' class="proof-container">
     Video Link:
-    <input name="records[{{ field_prefix }}][videourl]" type="text" size="32" value="{{ sub.videourl|e }}" onchange="updateProofIndicator('{{ field_prefix }}', '{{ mod_mode }}')" />
+    <input name="records[{{ field_prefix }}][videourl]" type="text" size="45" value="{{ sub.videourl|e }}" onchange="updateProofIndicator('{{ field_prefix }}', '{{ mod_mode }}')" />
     Screenshot Link:
-    <input name="records[{{ field_prefix }}][screenshoturl]" type="text" size="16" value="{{ sub.screenshoturl|e }}" />
+    <input name="records[{{ field_prefix }}][screenshoturl]" type="text" size="30" value="{{ sub.screenshoturl|e }}" />
 
     {% if mod_mode %}
       <input

--- a/templates/submission-entry.html
+++ b/templates/submission-entry.html
@@ -11,13 +11,17 @@
 
   <div class="value-fields">
     {% if sub_type != "S" %}
-      <input name='records[{{ field_prefix }}][time@m]' type='text' maxlength='1' size='1' value='{{ sub.time_m }}' />
+      <input name='records[{{ field_prefix }}][time@m]' type='text' maxlength='1' size='1' value='{{ sub.time_m }}' data-original-value='{{ sub.time_m }}' />
 
-      <input name='records[{{ field_prefix }}][time@s]' type='text' maxlength='2' size='2' value='{{ sub.time_s|format_time_part("Seconds") }}' />
+      {% with { value: sub.time_s|format_time_part("Seconds") } %}
+        <input name='records[{{ field_prefix }}][time@s]' type='text' maxlength='2' size='2' value='{{ value }}' data-original-value='{{ value }}' />
+      {% endwith %}
 
-      <input name='records[{{ field_prefix }}][time@t]' type='text' maxlength='4' size='4' value='{{ sub.time_t|format_time_part("Subseconds", ladder.timeformat) }}' />
+      {% with { value: sub.time_t|format_time_part("Subseconds", ladder.timeformat) } %}
+        <input name='records[{{ field_prefix }}][time@t]' type='text' maxlength='4' size='4' value='{{ value }}' data-original-value='{{ value }}' />
+      {% endwith %}
     {% else %}
-      <input name='records[{{ field_prefix }}][speed]' type='text' maxlength='6' size='6' value='{{ sub.speed }}' />
+      <input name='records[{{ field_prefix }}][speed]' type='text' maxlength='6' size='6' value='{{ sub.speed }}' data-original-value='{{ sub.speed }}' />
     {% endif %}
   </div>
 
@@ -41,24 +45,22 @@
     {% endif %}
   </div>
 
-  <!-- Platform; not present in every ladder -->
-  {% if ladder.platforms.platform %}
-    <div class="platform-container">
-      <label for="{{ field_prefix }}@platform"> Platform: </label>
+  <!-- Platform -->
+  <div class="platform-container">
+    <label for="{{ field_prefix }}@platform"> Platform: </label>
 
-      <select name="records[{{ field_prefix }}][platform]" id="{{ field_prefix }}@platform">
-        <option value=""></option>
+    <select name="records[{{ field_prefix }}][platform]" id="{{ field_prefix }}@platform" data-original-value="{{ sub.platform }}">
+      <option value=""></option>
 
-        {% for platform in ladder.platforms.platform %}
-          {% if platform == sub.platform %}
-            <option selected value="{{ platform }}">{{ platform }}</option>
-          {% else %}
-            <option value="{{ platform }}">{{ platform }}</option>
-          {% endif %}
-        {% endfor %}
-      </select>
-    </div>
-  {% endif %}
+      {% for platform in ladder.platforms.platform %}
+        {% if platform == sub.platform %}
+          <option selected value="{{ platform }}">{{ platform }}</option>
+        {% else %}
+          <option value="{{ platform }}">{{ platform }}</option>
+        {% endif %}
+      {% endfor %}
+    </select>
+  </div>
 
   <!-- Splits or comments (or neither) -->
   <div class="splits-comments-container">

--- a/templates/submission-entry.html
+++ b/templates/submission-entry.html
@@ -59,6 +59,18 @@
           <option value="{{ platform }}">{{ platform }}</option>
         {% endif %}
       {% endfor %}
+
+      {% if ladder.obsolete_platforms %}
+        <optgroup label="Obsolete">
+          {% for platform in ladder.obsolete_platforms.platform %}
+            {% if platform == sub.platform %}
+              <option selected value="{{ platform }}">{{ platform }}</option>
+            {% else %}
+              <option value="{{ platform }}">{{ platform }}</option>
+            {% endif %}
+          {% endfor %}
+        </optgroup>
+      {% endif %}
     </select>
   </div>
 

--- a/templates/viewplayer.html
+++ b/templates/viewplayer.html
@@ -12,10 +12,14 @@
   <thead>
     <tr>
       <td>{{ cup.cupname|e }}</td>
-      <td>Course time</td>
-      <td>Best lap</td>
-      {% if ladder.hasspeed == 'Yes' %}<td>Max speed</td>{% endif %}
-      <td></td>
+      <td colspan="3">Course time</td>
+      {% if ladder.haslap == 'Yes' %}
+        <td colspan="3">Best lap</td>
+      {% endif %}
+      {% if ladder.hasspeed == 'Yes' %}
+        <td colspan="2">Max speed</td>
+      {% endif %}
+      <td>Notes</td>
     </tr>
   </thead>
 
@@ -26,37 +30,83 @@
           <td>
             <a href='course.php?ladder={{ ladder_id }}&cup={{ cup.attributes.cupid }}&course={{ course.attributes.courseid }}'>{{ course.name|e }}</a>
           </td>
+
           <td>
-            <span>{{ record.C.value|format_time(ladder.timeformat) }}</span>
-            <img src="{{ record.C.ship_image|e }}" title="{{ record.C.ship }}" />
-            {% if record.C.has_proof %}
-              {{ record.C | proof_link }}
-            {% endif %}
+            {{ record.C.value|format_time(ladder.timeformat) }}
           </td>
-          <td>
-            {% if ladder.haslap == 'Yes' %}
-              <span>{{ record.L.value|format_time(ladder.timeformat) }}</span>
-              <img src="{{ record.L.ship_image|e }}" title="{{ record.L.ship }}" />
-              {% if record.L.has_proof %}
-                {{ record.L | proof_link }}
+
+          <td class="record-details">
+            <div class="record-ship-proof">
+              <img src="{{ record.C.ship_image|e }}" title="{{ record.C.ship }}" />
+              {% if record.C.has_proof %}
+                {{ record.C | proof_link }}
               {% endif %}
-            {% endif %}
+            </div>
+            <div class="record-platform" title="Platform this record was achieved on">
+              {{ record.C.platform }}
+            </div>
           </td>
-          {% if ladder.hasspeed == 'Yes' %}
+
+          <td class="record-rank-date">
+            <div class="record-rank" title="Ranking of this record">
+              {{ record.C.rank }} / {{ record.C.player_count}}
+            </div>
+            <div class="record-date" title="{{ record.C.last_change }}">
+              {{ record.C.date }}
+            </div>
+          </td>
+
+          {% if ladder.haslap == 'Yes' %}
             <td>
-              <span>{{ record.S.value }}</span>
-              <img src="{{ record.S.ship_image|e }}" title="{{ record.S.ship }}" />
-              {% if record.S.has_proof %}
-                {{ record.S | proof_link }}
-              {% endif %}
+              {{ record.L.value|format_time(ladder.timeformat) }}
+            </td>
+
+            <td class="record-details">
+              <div class="record-ship-proof">
+                <img src="{{ record.L.ship_image|e }}" title="{{ record.L.ship }}" />
+                {% if record.L.has_proof %}
+                  {{ record.L | proof_link }}
+                {% endif %}
+              </div>
+              <div class="record-platform" title="Platform this record was achieved on">
+                {{ record.L.platform }}
+              </div>
+            </td>
+
+            <td class="record-rank-date">
+              <div class="record-rank" title="Ranking of this record">
+                {{ record.L.rank }} / {{ record.L.player_count}}
+              </div>
+              <div class="record-date" title="{{ record.L.last_change }}">
+                {{ record.L.date }}
+              </div>
             </td>
           {% endif %}
-          <td>
+
+          {% if ladder.hasspeed == 'Yes' %}
+            <td>
+              {{ record.S.value }}
+            </td>
+
+            <td class="record-details">
+              <div class="record-ship-proof">
+                <img src="{{ record.S.ship_image|e }}" title="{{ record.S.ship }}" />
+                {% if record.S.has_proof %}
+                  {{ record.S | proof_link }}
+                {% endif %}
+              </div>
+              <div class="record-platform" title="Platform this record was achieved on">
+                {{ record.S.platform }}
+              </div>
+            </td>
+          {% endif %}
+
+          <td class="notes">
             <div class='splits'>
-              Splits: {{ record.C.notes|e }}
+              {{ record.C.notes|e }}
             </div>
             <div class='comments'>
-              Comment: {{ record.L.notes|e }}
+              {{ record.L.notes|e }}
             </div>
           </td>
         </tr>
@@ -67,15 +117,20 @@
       <td>
         <span>{{ totals[cup.attributes.cupid.__toString].C|format_time(ladder.timeformat) }}</span>
       </td>
-      <td>
-        {% if ladder.haslap == 'Yes' %}
+      <td class="record-details"></td>
+      <td class="record-details"></td>
+      {% if ladder.haslap == 'Yes' %}
+        <td>
           <span>{{ totals[cup.attributes.cupid.__toString].L|format_time(ladder.timeformat) }}</span>
-        {% endif %}
-      </td>
+        </td>
+        <td class="record-details"></td>
+        <td class="record-details"></td>
+      {% endif %}
       {% if ladder.hasspeed == 'Yes' %}
         <td>
           <span>{{ totals[cup.attributes.cupid.__toString].S }}</span>
         </td>
+        <td class="record-details"></td>
       {% endif %}
       <td></td>
     </tr>
@@ -89,9 +144,8 @@
     <tr>
       <td>Totals</td>
       <td>Course time</td>
-      <td>Best lap</td>
+      {% if ladder.haslap == 'Yes' %}<td>Best lap</td>{% endif %}
       {% if ladder.hasspeed == 'Yes' %}<td>Max speed</td>{% endif %}
-      <td></td>
     </tr>
   </thead>
 
@@ -101,17 +155,16 @@
       <td>
         {{ totals[0].C | format_time(ladder.timeformat) }}
       </td>
-      <td>
-        {% if ladder.haslap == 'Yes' %}
+      {% if ladder.haslap == 'Yes' %}
+        <td>
           {{ totals[0].L | format_time(ladder.timeformat) }}
-        {% endif %}
-      </td>
+        </td>
+      {% endif %}
       {% if ladder.hasspeed == 'Yes' %}
         <td>
           {{ totals[0].S }}
         </td>
       {% endif %}
-      <td></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Platform options:

- Have been added for all ladders in all games; previously only Climax had them. These go up to and including GX on Switch 2's NSO, which released a week ago.
- Platform is required for all new and updated records (updated meaning when the actual time or speed changes). If it's not filled in, you're prevented from submitting the form. This is intended to catch cases where people accidentally submit without picking a platform. However, it's not intended to be watertight enforcement, so hopefully people don't try to circumvent it.
- The `GBA` platform option for Climax is now considered obsolete. So, it's grouped under an `Obsolete` optgroup label, and choosing it for new or updated records prevents you from submitting the form.

![image](https://github.com/user-attachments/assets/2f78f2c5-ecd5-4d9e-be90-c19c1754f0c5)

![image](https://github.com/user-attachments/assets/427b33fc-6942-4f5e-b011-645a1dd99b8e)

Rules updates:

- GX rules now allow NSO on Switch 2, and specify rules for save state usage.
- GX rules now allow self-burned discs as a "USB/SD Loader" playing method. (Sort of a tangential change, but it's in here anyway.)
- X rules now acknowledge rewinds on NSO, since that capability was added on Switch 2.

Layout updates:

- Course ranking pages now show platform values on lap times and speeds, not just course times.
- Player records pages now show platforms, and incidentally also ranks and dates since there was room to fit more info.
- A few tooltips have been added to record-detail elements on both of the above pages.
- 'Latest records for ladder' pages no longer have a placeholder rank column. I just removed that column, since it's harder to make ranks compute quickly here compared to the player pages, and it's not quite as useful to see ranks on this page anyway.
- Times submission pages now have more consistent field width for the actual times/speeds between browsers, and incidentally the max lengths of the fields have been shortened (millisecond: 4 -> 3, speed: 6 -> 4). The Climax submission page no longer has the "Add proof" words on their own row.

![image](https://github.com/user-attachments/assets/66c03e72-4306-4345-92ba-4839cb3c2171)
