### PR TITLE
Community update links for May/Jun 2025

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -113,7 +113,7 @@
       <!-- Logo image on left -->
       <img src="/images/header.png" alt="F-Zero Central" USEMAP="#fzerotop_Map" style="padding-right: 60px">
       <!-- Links -->
-      <a class="logo-menu-item" style="left: 238; top: 45;" href="https://docs.google.com/document/d/1CXEJIAtL3Axnn2GbhkZk-NJTGoXtg5oXOvH_Uxi3Ndg/edit">Community Update (Mar/Apr)</a>
+      <a class="logo-menu-item" style="left: 238; top: 45;" href="https://docs.google.com/document/d/1wZvwAsyJwj83bfiegCWVEn6EQ_WI3dlRlkiSuKAI8jo/edit">Community Update (May/Jun)</a>
       <a class="logo-menu-item" style="left: 231; top: 70;" href="https://discord.gg/wT4RWTPTHk">Discord Server</a>
       <a class="logo-menu-item" style="left: 222; top: 95;" href="/overall_ladder.php">Overall Ladder</a>
       <a class="logo-menu-item" style="left: 210; top: 120;" href="/championships_ladder.php">Championships</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,8 @@
               <span>News</span>
             </div>
             <div class="home-page-box-body news">
+              <a href="https://docs.google.com/document/d/1wZvwAsyJwj83bfiegCWVEn6EQ_WI3dlRlkiSuKAI8jo/edit">FZC Community Update May/Jun 2025</a><br>
+              <small>July 1, 2025<br><br></small>
               <a href="https://docs.google.com/document/d/1CXEJIAtL3Axnn2GbhkZk-NJTGoXtg5oXOvH_Uxi3Ndg/edit">FZC Community Update Mar/Apr 2025</a><br>
               <small>May 1, 2025<br><br></small>
               <a href="https://docs.google.com/document/d/1nEQU8a6MVabvt7CVFmape74-5rqBoe2uWOqblueM9Bk/edit">FZC Community Update Jan/Feb 2025</a><br>


### PR DESCRIPTION
This time I'm leaving 6 news links on the front page instead of the usual 5, because 6 makes the current layout more symmetrical (since we removed the Twitter feed). Also, having exactly one years' worth of community updates there just feels right.