### PR TITLE
Ladder latest records: add pagination

### DIFF
--- a/public/fzero.css
+++ b/public/fzero.css
@@ -868,6 +868,7 @@ div.home-page-ladder-group > div.body > a:hover {
   border: 1px black solid;
   border-radius: 10px;
   border-spacing: 0px;
+  margin-bottom: 20px;
 }
 
 /* Alternate colors between rows. */
@@ -1083,7 +1084,6 @@ div.ladder-leaders > div > div > span {
 .page-player-ladder .lap-label { grid-area: lap-label; }
 .page-player-ladder .lap-value { grid-area: lap-value; display: flex; gap: 10px; }
 .page-player-ladder .splits { grid-area: splits; }
-.page-player-ladder .scoreboard { margin-bottom: 20px; }
 
 .section-box {
   font: 10pt Verdana; background-color: #f7f7f7; padding: 10px 20px; margin-bottom: 20px; border: 1px black solid; border-radius: 10px;

--- a/public/ladder_latest.php
+++ b/public/ladder_latest.php
@@ -5,8 +5,12 @@ require_once '../common.php';
 $ladder_id = intval($_GET['id'] ?? 0);
 $ladder = FserverLadder($ladder_id);
 
+$page_number = intval($_GET['page'] ?? 1);
+$page_number = max($page_number, 1);
+$offset = ($page_number - 1) * 100;
+
 $entries = [];
-// AF
+
 $result = db_query("
   SELECT
     phpbb_f0_records.*,
@@ -16,7 +20,7 @@ $result = db_query("
   JOIN phpbb_users USING (user_id)
   WHERE ladder_id = $ladder_id
   ORDER BY last_change DESC
-  LIMIT 100
+  LIMIT 100 OFFSET $offset
 ");
 
 $index = 1;
@@ -40,5 +44,6 @@ echo render_template($template, [
   'entries' => $entries,
   'ladder' => $ladder,
   'ladder_id' => $ladder_id,
+  'page_number' => $page_number,
   'selected_game' => ladder_game($ladder_id),
 ]);

--- a/templates/ladder_latest.html
+++ b/templates/ladder_latest.html
@@ -11,7 +11,7 @@
   <table class='scoreboard'>
     <thead>
       <tr>
-        <td colspan='2'>Player</td>
+        <td>Player</td>
         <td>Cup</td>
         <td>Course</td>
         <td>Type</td>
@@ -26,7 +26,6 @@
     <tbody class='entries'>
       {% for entry in entries %}
         <tr>
-          <td>{{ entry.position }}</td>
           <td>
             {{ entry.location|flag }}
 
@@ -58,4 +57,16 @@
       {% endfor %}
     </tbody>
   </table>
+
+  <div class="section-box">
+    Page:
+
+    {% if page_number > 1 %}
+      <a href="?id={{ ladder_id }}&page={{ page_number - 1 }}">{{ page_number - 1 }}</a>
+    {% endif %}
+
+    {{ page_number }}
+
+    <a href="?id={{ ladder_id }}&page={{ page_number + 1 }}">{{ page_number + 1 }}</a>
+  </div>
 {% endblock %}


### PR DESCRIPTION
100 records per page. It seems to perform well even if you go to page 50 or so.

Slightly lazy bit in the implementation: it'll keep showing next-page-number links even if it's stopped getting results. But continuing to advance doesn't get any errors at least, just blank results.