### PR TITLE
Player pages: show average rank for each record type in the ladder

### DIFF
--- a/templates/viewplayer.html
+++ b/templates/viewplayer.html
@@ -142,7 +142,7 @@
 <table class='scoreboard'>
   <thead>
     <tr>
-      <td>Totals</td>
+      <td>{{ ladder.ladder_name|e }} overall stats</td>
       <td>Course time</td>
       {% if ladder.haslap == 'Yes' %}<td>Best lap</td>{% endif %}
       {% if ladder.hasspeed == 'Yes' %}<td>Max speed</td>{% endif %}
@@ -151,7 +151,7 @@
 
   <tbody class='entries'>
     <tr>
-      <td>{{ ladder.ladder_name|e }} totals</td>
+      <td>Total</td>
       <td>
         {{ totals[0].C | format_time(ladder.timeformat) }}
       </td>
@@ -163,6 +163,22 @@
       {% if ladder.hasspeed == 'Yes' %}
         <td>
           {{ totals[0].S }}
+        </td>
+      {% endif %}
+    </tr>
+
+    <tr>
+      <td>Average rank</td>
+      <td>
+        {{ average_ranks.C }}
+      </td>
+      {% if ladder.haslap == 'Yes' %}
+        <td>
+          {{ average_ranks.L }}
+        </td>
+      {% endif %}
+      {% if ladder.hasspeed == 'Yes' %}
+        <td>
         </td>
       {% endif %}
     </tr>


### PR DESCRIPTION
This used to be a thing pre-2021, but had been absent since. But now that the player pages have ranks for each record (since PR #72), getting the average rank here is just a matter of, well, averaging those ranks.

Average rank is also known as average finish (AF), but going with the 'average rank' wording for now to have a bit more differentiation from 'AF score' which the ladder-ranking pages still use.