### PR TITLE
GX rules: reword the rule on using AR to unlock the special parts

### DIFF
--- a/rules/gx.md
+++ b/rules/gx.md
@@ -18,7 +18,7 @@
 
 1. The use of cheat devices such as Action Replay are forbidden on all of the ladders. If it is suspected that a cheat device has been used, then that player will have their times removed from the ladder.
 
-    - NOTE: An exception has been made to F-ZERO GX, as Action Replay is the only method available to unlock the Japanese AX event parts. Players should use the AR only once to unlock them.
+    - EXCEPTION: Action Replay may only be used to unlock the event-exclusive custom parts (gold colored) in the shop on your GX save file. After you buy these parts from the shop, you will not need codes to use them. See [CGN's article](https://crazygamenerd.web.fc2.com/FZGX_SP_Machines.html) about these "Special Machine Parts" for tutorials on how to access the parts, with or without AR.
 
 
 ## USB/SD Loader Rules


### PR DESCRIPTION
Particularly avoiding calling them anything close to "AX parts" since that is misleading.

We now link to CGN's recently updated article which should explain the special parts clearly and thoroughly.

Suggested by Uchiha around June last year, just getting around to it now.