### PR TITLE
Community update links: 2026 Lap 1/4

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -113,7 +113,7 @@
       <!-- Logo image on left -->
       <img src="/images/header.png" alt="F-Zero Central" USEMAP="#fzerotop_Map" style="padding-right: 60px">
       <!-- Links -->
-      <a class="logo-menu-item" style="left: 238; top: 45;" href="https://docs.google.com/document/d/1xpw0H5aflTalMl5FwEUGB3L_GmHnUdGstugSBXP-_SA/edit">Community Update (Nov/Dec)</a>
+      <a class="logo-menu-item" style="left: 238; top: 45;" href="https://docs.google.com/document/d/192jUpvY9E03hPlk863latHrU5DBgTCy1hsqBWpBrSbI/edit?usp=sharing">Community Update (Lap 1/4)</a>
       <a class="logo-menu-item" style="left: 231; top: 70;" href="https://discord.gg/wT4RWTPTHk">Discord Server</a>
       <a class="logo-menu-item" style="left: 222; top: 95;" href="/overall_ladder.php">Overall Ladder</a>
       <a class="logo-menu-item" style="left: 210; top: 120;" href="/championships_ladder.php">Championships</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,8 @@
               <span>News</span>
             </div>
             <div class="home-page-box-body news">
+              <a href="https://docs.google.com/document/d/192jUpvY9E03hPlk863latHrU5DBgTCy1hsqBWpBrSbI/edit?usp=sharing">FZC Community Update 2026 Lap 1/4</a><br>
+              <small>March 31, 2026<br><br></small>
               <a href="https://docs.google.com/document/d/1xpw0H5aflTalMl5FwEUGB3L_GmHnUdGstugSBXP-_SA/edit">FZC Community Update Nov/Dec 2025</a><br>
               <small>December 31, 2025<br><br></small>
               <a href="https://docs.google.com/document/d/10k433c4mImEAOwoDxAG-YFns0Yk-H8bj12SRquFXkBY/edit">FZC Community Update Sep/Oct 2025</a><br>
@@ -18,8 +20,6 @@
               <small>July 1, 2025<br><br></small>
               <a href="https://docs.google.com/document/d/1CXEJIAtL3Axnn2GbhkZk-NJTGoXtg5oXOvH_Uxi3Ndg/edit">FZC Community Update Mar/Apr 2025</a><br>
               <small>May 1, 2025<br><br></small>
-              <a href="https://docs.google.com/document/d/1nEQU8a6MVabvt7CVFmape74-5rqBoe2uWOqblueM9Bk/edit">FZC Community Update Jan/Feb 2025</a><br>
-              <small>March 1, 2025<br><br></small>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Also: I used to leave out the `?usp=sharing` part of the URL for consistency with previous links, but now I figured I might as well leave it in to match the links Yazzo posts on Bluesky/Discord. (Not actually sure if there's a technical difference.)